### PR TITLE
Supplemental packages

### DIFF
--- a/docs/spec.schema.json
+++ b/docs/spec.schema.json
@@ -2198,6 +2198,74 @@
 			],
 			"description": "Spec is the specification for a package build."
 		},
+		"SubPackage": {
+			"required": [
+				"description"
+			],
+			"properties": {
+				"artifacts": {
+					"$ref": "#/$defs/Artifacts",
+					"description": "Artifacts specifies which build outputs go into this supplemental package.\nThis is self-contained — no artifacts are inherited from the primary package."
+				},
+				"conflicts": {
+					"$ref": "#/$defs/PackageDependencyList",
+					"description": "Conflicts is the list of packages that conflict with this supplemental package."
+				},
+				"dependencies": {
+					"$ref": "#/$defs/SubPackageDependencies",
+					"description": "Dependencies specifies runtime dependencies for this supplemental package.\nOnly runtime and recommends dependencies are allowed; build dependencies\nare shared with the primary package."
+				},
+				"description": {
+					"type": [
+						"string"
+					],
+					"description": "Description is the package description. This is required — both RPM and\nDebian require a description/summary for every subpackage."
+				},
+				"name": {
+					"type": [
+						"string",
+						"null"
+					],
+					"description": "Name overrides the default package name.\nBy default, the package name is \"\u003cparent\u003e-\u003ckey\u003e\" where \u003ckey\u003e is the map\nkey under which this SubPackage is defined. Set this to use a fully custom\npackage name instead."
+				},
+				"provides": {
+					"$ref": "#/$defs/PackageDependencyList",
+					"description": "Provides is the list of things this supplemental package provides."
+				},
+				"replaces": {
+					"$ref": "#/$defs/PackageDependencyList",
+					"description": "Replaces is the list of packages that this supplemental package replaces/obsoletes."
+				}
+			},
+			"additionalProperties": {
+				"not": {}
+			},
+			"type": [
+				"object",
+				"null"
+			],
+			"description": "SubPackage defines a supplemental package produced from the same build output as the primary package."
+		},
+		"SubPackageDependencies": {
+			"properties": {
+				"recommends": {
+					"$ref": "#/$defs/PackageDependencyList",
+					"description": "Recommends is the list of packages recommended to install with the supplemental package.\nNote: Not all package managers support this (e.g. rpm)"
+				},
+				"runtime": {
+					"$ref": "#/$defs/PackageDependencyList",
+					"description": "Runtime is the list of packages required to install/run the supplemental package."
+				}
+			},
+			"additionalProperties": {
+				"not": {}
+			},
+			"type": [
+				"object",
+				"null"
+			],
+			"description": "SubPackageDependencies contains only the dependency fields valid for supplemental packages."
+		},
 		"SymlinkTarget": {
 			"required": [
 				"path",
@@ -2374,6 +2442,16 @@
 				"package_config": {
 					"$ref": "#/$defs/PackageConfig",
 					"description": "PackageConfig is the configuration to use for artifact targets, such as\nrpms, debs, or zip files containing Windows binaries"
+				},
+				"packages": {
+					"additionalProperties": {
+						"$ref": "#/$defs/SubPackage"
+					},
+					"type": [
+						"object",
+						"null"
+					],
+					"description": "Packages defines supplemental packages produced from the same build output\nas the primary package. Each entry produces an additional package with its\nown artifact selection, runtime dependencies, and metadata.\nThe map key is used as a suffix for the default package name (\"\u003cspecName\u003e-\u003ckey\u003e\")."
 				},
 				"provides": {
 					"$ref": "#/$defs/PackageDependencyList",

--- a/load.go
+++ b/load.go
@@ -577,6 +577,9 @@ func (s Spec) Validate() error {
 		if err := t.validate(); err != nil {
 			errs = append(errs, errors.Wrapf(err, "target %s", k))
 		}
+		if err := validateSubPackageNames(s.Name, k, t.Packages); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	if err := s.Image.validate(); err != nil {

--- a/packaging/linux/deb/debroot.go
+++ b/packaging/linux/deb/debroot.go
@@ -154,10 +154,10 @@ func Debroot(ctx context.Context, sOpt dalec.SourceOpts, spec *dalec.Spec, worke
 		return dalec.ErrorState(in, errors.Wrap(err, "error generating custom systemd postinst"))
 	}
 
-	if len(customEnable) > 0 {
+	for _, partial := range customEnable {
 		// This is not meant to be executed on its own and will instead get added
 		// to a post inst file, so need to mark this as executable.
-		states = append(states, dalecDir.File(llb.Mkfile(filepath.Join(dir, "dalec/"+customSystemdPostinstFile), 0o600, customEnable), opts...))
+		states = append(states, dalecDir.File(llb.Mkfile(filepath.Join(dir, "dalec/"+partial.partialFile()), 0o600, partial.content), opts...))
 	}
 
 	postinst := generatePostinst(spec, target)
@@ -165,24 +165,25 @@ func Debroot(ctx context.Context, sOpt dalec.SourceOpts, spec *dalec.Spec, worke
 		states = append(states, dalecDir.File(llb.Mkfile(filepath.Join(dir, "postinst"), 0o700, postinst), opts...))
 	}
 
+	// Generate postinst scripts for subpackages
+	packages := spec.GetSubPackages(target)
+	if len(packages) > 0 {
+		subKeys := dalec.SortMapKeys(packages)
+		for _, key := range subKeys {
+			pkg := packages[key]
+			resolvedName := pkg.ResolvedName(spec.Name, key)
+			subPostinst := generateSubPackagePostinst(pkg.Artifacts, resolvedName)
+			if len(subPostinst) > 0 {
+				states = append(states, dalecDir.File(llb.Mkfile(filepath.Join(dir, resolvedName+".postinst"), 0o700, subPostinst), opts...))
+			}
+		}
+	}
+
 	patchDir := dalecDir.File(llb.Mkdir(filepath.Join(dir, "dalec/patches"), 0o755), opts...)
 	sorted := dalec.SortMapKeys(spec.Patches)
 	for _, name := range sorted {
 		pls := sourcePatchesDir(sOpt, patchDir, filepath.Join(dir, "dalec/patches"), name, spec, opts...)
 		states = append(states, pls...)
-	}
-
-	artifacts := spec.GetArtifacts(target)
-	if len(artifacts.Links) > 0 {
-		buf := bytes.NewBuffer(nil)
-
-		for _, l := range artifacts.Links {
-			src := strings.TrimPrefix(l.Source, "/")
-			dst := strings.TrimPrefix(l.Dest, "/")
-			fmt.Fprintln(buf, src, dst)
-		}
-
-		states = append(states, dalecDir.File(llb.Mkfile(filepath.Join(dir, spec.Name+".links"), 0o644, buf.Bytes()), opts...))
 	}
 
 	return dalec.MergeAtPath(in, states, "/", opts...)
@@ -194,8 +195,8 @@ func generatePostinst(spec *dalec.Spec, target string) []byte {
 	artifacts := spec.GetArtifacts(target)
 	writeUsersPostInst(buf, artifacts.Users)
 	writeGroupsPostInst(buf, artifacts.Groups)
-	setArtifactOwnershipPostInst(buf, spec, target)
-	setArtifactCapabilitiesPostInst(buf, spec, target)
+	writeArtifactOwnershipPostInst(buf, &artifacts, spec.Name)
+	writeArtifactCapabilitiesPostInst(buf, &artifacts)
 
 	if buf.Len() == 0 {
 		return nil
@@ -210,20 +211,67 @@ func generatePostinst(spec *dalec.Spec, target string) []byte {
 	return dt
 }
 
+// generateSubPackagePostinst generates a postinst script for a subpackage.
+// Returns nil if no postinst actions are needed.
+func generateSubPackagePostinst(artifacts *dalec.Artifacts, pkgName string) []byte {
+	if artifacts == nil {
+		return nil
+	}
+
+	buf := bytes.NewBuffer(nil)
+
+	writeUsersPostInst(buf, artifacts.Users)
+	writeGroupsPostInst(buf, artifacts.Groups)
+	writeArtifactOwnershipPostInst(buf, artifacts, pkgName)
+	writeArtifactCapabilitiesPostInst(buf, artifacts)
+
+	if buf.Len() == 0 {
+		return nil
+	}
+
+	dt := []byte("#!/usr/bin/env sh\nset -e\n\n#DEBHELPER#\n\n")
+	dt = append(dt, buf.Bytes()...)
+
+	return dt
+}
+
 func fixupArtifactPerms(spec *dalec.Spec, target string, cfg *SourcePkgConfig) []byte {
 	buf := bytes.NewBuffer(nil)
 	writeScriptHeader(buf, cfg)
 
-	basePath := filepath.Join("debian", spec.Name)
+	// Fix permissions for the primary package
 	artifacts := spec.GetArtifacts(target)
+	writePackagePerms(buf, spec, &artifacts, spec.Name)
 
-	checkAndWritePerms := func(artifacts map[string]dalec.ArtifactConfig, dir string) {
-		if artifacts == nil {
+	// Fix permissions for subpackages
+	packages := spec.GetSubPackages(target)
+	if len(packages) > 0 {
+		keys := dalec.SortMapKeys(packages)
+		for _, key := range keys {
+			pkg := packages[key]
+			if pkg.Artifacts == nil {
+				continue
+			}
+			resolvedName := pkg.ResolvedName(spec.Name, key)
+			writePackagePerms(buf, spec, pkg.Artifacts, resolvedName)
+		}
+	}
+
+	return buf.Bytes()
+}
+
+// writePackagePerms writes chmod commands for a single package's artifacts.
+// spec is needed for inline source permission lookups.
+func writePackagePerms(buf *bytes.Buffer, spec *dalec.Spec, artifacts *dalec.Artifacts, pkgName string) {
+	basePath := filepath.Join("debian", pkgName)
+
+	checkAndWritePerms := func(cfgs map[string]dalec.ArtifactConfig, dir string) {
+		if cfgs == nil {
 			return
 		}
-		sorted := dalec.SortMapKeys(artifacts)
+		sorted := dalec.SortMapKeys(cfgs)
 		for _, key := range sorted {
-			cfg := artifacts[key]
+			cfg := cfgs[key]
 			resolvedName := cfg.ResolveName(key)
 			p := filepath.Join(basePath, dir, resolvedName)
 			// TODO: do i need this?
@@ -266,10 +314,10 @@ func fixupArtifactPerms(spec *dalec.Spec, target string, cfg *SourcePkgConfig) [
 
 	checkAndWritePerms(artifacts.Binaries, BinariesPath)
 	checkAndWritePerms(artifacts.ConfigFiles, ConfigFilesPath)
-	checkAndWritePerms(artifacts.Manpages, filepath.Join(ManpagesPath, spec.Name))
+	checkAndWritePerms(artifacts.Manpages, filepath.Join(ManpagesPath, pkgName))
 	checkAndWritePerms(artifacts.Headers, HeadersPath)
-	checkAndWritePerms(artifacts.Licenses, filepath.Join(LicensesPath, spec.Name))
-	checkAndWritePerms(artifacts.Docs, filepath.Join(DocsPath, spec.Name))
+	checkAndWritePerms(artifacts.Licenses, filepath.Join(LicensesPath, pkgName))
+	checkAndWritePerms(artifacts.Docs, filepath.Join(DocsPath, pkgName))
 	checkAndWritePerms(artifacts.Libs, LibsPath)
 	checkAndWritePerms(artifacts.Libexec, LibexecPath)
 	checkAndWritePerms(artifacts.DataDirs, DataDirsPath)
@@ -293,8 +341,6 @@ func fixupArtifactPerms(spec *dalec.Spec, target string, cfg *SourcePkgConfig) [
 			}
 		}
 	}
-
-	return buf.Bytes()
 }
 
 // For debian sources
@@ -403,22 +449,47 @@ func createBuildScript(spec *dalec.Spec, cfg *SourcePkgConfig) []byte {
 
 func createInstallScripts(worker llb.State, spec *dalec.Spec, dir, target string, opts ...llb.ConstraintsOpt) []llb.State {
 	artifacts := spec.GetArtifacts(target)
-
-	states := make([]llb.State, 1)
 	base := llb.Scratch().File(llb.Mkdir(dir, 0o755, llb.WithParents(true)), opts...)
+
+	states := packageInstallScripts(worker, base, &artifacts, spec.Name, dir, opts...)
+
+	// Generate install scripts for each subpackage
+	packages := spec.GetSubPackages(target)
+	if len(packages) > 0 {
+		keys := dalec.SortMapKeys(packages)
+		for _, key := range keys {
+			pkg := packages[key]
+			resolvedName := pkg.ResolvedName(spec.Name, key)
+			var pkgArtifacts dalec.Artifacts
+			if pkg.Artifacts != nil {
+				pkgArtifacts = *pkg.Artifacts
+			}
+			subStates := packageInstallScripts(worker, base, &pkgArtifacts, resolvedName, dir, opts...)
+			states = append(states, subStates...)
+		}
+	}
+
+	return states
+}
+
+// packageInstallScripts generates the .install, .manpages, .dirs, .docs, and
+// systemd symlink states for a single package (primary or subpackage).
+// pkgName is the resolved package name used for file prefixes and debian/ destination paths.
+func packageInstallScripts(worker llb.State, base llb.State, artifacts *dalec.Artifacts, pkgName, dir string, opts ...llb.ConstraintsOpt) []llb.State {
+	var states []llb.State
 
 	installBuf := bytes.NewBuffer(nil)
 	writeInstallHeader := sync.OnceFunc(func() {
 		fmt.Fprintln(installBuf, string(debianInstall))
 	})
 
-	writeInstall := func(src, dir, name string) {
+	writeInstall := func(src, destDir, name string) {
 		// This is wrapped in a sync.OnceFunc so that this only has an effect the
 		// first time it is called.
 		writeInstallHeader()
 
 		name = strings.TrimSuffix(name, "*")
-		dest := filepath.Join("debian", spec.Name, dir, name)
+		dest := filepath.Join("debian", pkgName, destDir, name)
 		fmt.Fprintln(installBuf, "do_install", filepath.Dir(dest), dest, src)
 	}
 
@@ -449,13 +520,13 @@ func createInstallScripts(worker llb.State, spec *dalec.Spec, dir, target string
 			cfg := artifacts.Manpages[key]
 			if cfg.Name != "" || (cfg.SubPath != "" && cfg.SubPath != filepath.Base(filepath.Dir(key))) {
 				resolved := cfg.ResolveName(key)
-				writeInstall(key, filepath.Join(ManpagesPath, spec.Name, cfg.SubPath), resolved)
+				writeInstall(key, filepath.Join(ManpagesPath, pkgName, cfg.SubPath), resolved)
 				continue
 			}
 			fmt.Fprintln(buf, key)
 		}
 		if buf.Len() > 0 {
-			states = append(states, base.File(llb.Mkfile(filepath.Join(dir, spec.Name+".manpages"), 0o640, buf.Bytes()), opts...))
+			states = append(states, base.File(llb.Mkfile(filepath.Join(dir, pkgName+".manpages"), 0o640, buf.Bytes()), opts...))
 		}
 
 	}
@@ -473,7 +544,7 @@ func createInstallScripts(worker llb.State, spec *dalec.Spec, dir, target string
 			fmt.Fprintln(buf, filepath.Join("/var/lib", name))
 		}
 
-		states = append(states, base.File(llb.Mkfile(filepath.Join(dir, spec.Name+".dirs"), 0o640, buf.Bytes()), opts...))
+		states = append(states, base.File(llb.Mkfile(filepath.Join(dir, pkgName+".dirs"), 0o640, buf.Bytes()), opts...))
 	}
 
 	if len(artifacts.Docs) > 0 || len(artifacts.Licenses) > 0 {
@@ -484,7 +555,7 @@ func createInstallScripts(worker llb.State, spec *dalec.Spec, dir, target string
 			cfg := artifacts.Docs[key]
 			resolved := cfg.ResolveName(key)
 			if resolved != key || cfg.SubPath != "" {
-				writeInstall(key, filepath.Join(DocsPath, spec.Name, cfg.SubPath), resolved)
+				writeInstall(key, filepath.Join(DocsPath, pkgName, cfg.SubPath), resolved)
 			} else {
 				fmt.Fprintln(buf, key)
 			}
@@ -495,14 +566,14 @@ func createInstallScripts(worker llb.State, spec *dalec.Spec, dir, target string
 			cfg := artifacts.Licenses[key]
 			resolved := cfg.ResolveName(key)
 			if resolved != key || cfg.SubPath != "" {
-				writeInstall(key, filepath.Join(LicensesPath, spec.Name, cfg.SubPath), resolved)
+				writeInstall(key, filepath.Join(LicensesPath, pkgName, cfg.SubPath), resolved)
 			} else {
 				fmt.Fprintln(buf, key)
 			}
 		}
 
 		if buf.Len() > 0 {
-			states = append(states, base.File(llb.Mkfile(filepath.Join(dir, spec.Name+".docs"), 0o640, buf.Bytes()), opts...))
+			states = append(states, base.File(llb.Mkfile(filepath.Join(dir, pkgName+".docs"), 0o640, buf.Bytes()), opts...))
 		}
 	}
 
@@ -531,8 +602,8 @@ func createInstallScripts(worker llb.State, spec *dalec.Spec, dir, target string
 		for _, key := range sorted {
 			cfg := units[key]
 			name, suffix := cfg.SplitName(key)
-			if name != spec.Name {
-				name = spec.Name + "." + name
+			if name != pkgName {
+				name = pkgName + "." + name
 			}
 
 			name = name + "." + suffix
@@ -589,8 +660,18 @@ func createInstallScripts(worker llb.State, spec *dalec.Spec, dir, target string
 		}
 	}
 
+	if len(artifacts.Links) > 0 {
+		buf := bytes.NewBuffer(nil)
+		for _, l := range artifacts.Links {
+			src := strings.TrimPrefix(l.Source, "/")
+			dst := strings.TrimPrefix(l.Dest, "/")
+			fmt.Fprintln(buf, src, dst)
+		}
+		states = append(states, base.File(llb.Mkfile(filepath.Join(dir, pkgName+".links"), 0o644, buf.Bytes()), opts...))
+	}
+
 	if installBuf.Len() > 0 {
-		states = append(states, base.File(llb.Mkfile(filepath.Join(dir, spec.Name+".install"), 0o700, installBuf.Bytes()), opts...))
+		states = append(states, base.File(llb.Mkfile(filepath.Join(dir, pkgName+".install"), 0o700, installBuf.Bytes()), opts...))
 	}
 
 	return states
@@ -684,9 +765,7 @@ func writeGroupsPostInst(w *bytes.Buffer, groups []dalec.AddGroupConfig) {
 	}
 }
 
-func setArtifactOwnershipPostInst(w *bytes.Buffer, spec *dalec.Spec, target string) {
-	artifacts := spec.GetArtifacts(target)
-
+func writeArtifactOwnershipPostInst(w *bytes.Buffer, artifacts *dalec.Artifacts, pkgName string) {
 	apply := func(artifacts map[string]dalec.ArtifactConfig, root string) {
 		if artifacts == nil {
 			return
@@ -707,10 +786,10 @@ func setArtifactOwnershipPostInst(w *bytes.Buffer, spec *dalec.Spec, target stri
 
 	apply(artifacts.Binaries, BinariesPath)
 	apply(artifacts.ConfigFiles, ConfigFilesPath)
-	apply(artifacts.Manpages, filepath.Join(ManpagesPath, spec.Name))
+	apply(artifacts.Manpages, filepath.Join(ManpagesPath, pkgName))
 	apply(artifacts.Headers, HeadersPath)
-	apply(artifacts.Licenses, filepath.Join(LicensesPath, spec.Name))
-	apply(artifacts.Docs, filepath.Join(DocsPath, spec.Name))
+	apply(artifacts.Licenses, filepath.Join(LicensesPath, pkgName))
+	apply(artifacts.Docs, filepath.Join(DocsPath, pkgName))
 	apply(artifacts.Libs, LibsPath)
 	apply(artifacts.Libexec, LibexecPath)
 	apply(artifacts.DataDirs, DataDirsPath)
@@ -746,9 +825,7 @@ func setArtifactOwnershipPostInst(w *bytes.Buffer, spec *dalec.Spec, target stri
 	}
 }
 
-func setArtifactCapabilitiesPostInst(w *bytes.Buffer, spec *dalec.Spec, target string) {
-	artifacts := spec.GetArtifacts(target)
-
+func writeArtifactCapabilitiesPostInst(w *bytes.Buffer, artifacts *dalec.Artifacts) {
 	apply := func(artifacts map[string]dalec.ArtifactConfig, root string) {
 		if artifacts == nil {
 			return

--- a/packaging/linux/deb/debroot_subpackage_test.go
+++ b/packaging/linux/deb/debroot_subpackage_test.go
@@ -1,0 +1,737 @@
+package deb
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/project-dalec/dalec"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func TestDebrootSubPackageInstallFile(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	spec := &dalec.Spec{
+		Name:        "example",
+		Description: "Example package",
+		Version:     "1.0.0",
+		Revision:    "1",
+		License:     "Apache-2.0",
+		Targets: map[string]dalec.Target{
+			"testdistro": {
+				Packages: map[string]dalec.SubPackage{
+					"libs": {
+						Description: "Library files",
+						Artifacts: &dalec.Artifacts{
+							Binaries: map[string]dalec.ArtifactConfig{
+								"mylib-cli": {},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	st := Debroot(ctx, dalec.SourceOpts{}, spec, llb.Scratch(), llb.Scratch(), "testdistro", "", "", SourcePkgConfig{})
+	def, err := st.Marshal(ctx)
+	assert.NilError(t, err)
+
+	// Subpackage should produce an .install file with the resolved name
+	mkfile, err := findMkfile(t, def.ToPB(), filepath.Join("/debian", "example-libs.install"))
+	assert.NilError(t, err)
+	assert.Assert(t, mkfile != nil, "expected example-libs.install to be generated")
+
+	// The install file should reference the subpackage's destination path
+	assert.Assert(t, cmp.Contains(string(mkfile.Data), "debian/example-libs"))
+	assert.Assert(t, cmp.Contains(string(mkfile.Data), "mylib-cli"))
+}
+
+func TestDebrootSubPackageCustomName(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	spec := &dalec.Spec{
+		Name:        "example",
+		Description: "Example package",
+		Version:     "1.0.0",
+		Revision:    "1",
+		License:     "Apache-2.0",
+		Targets: map[string]dalec.Target{
+			"testdistro": {
+				Packages: map[string]dalec.SubPackage{
+					"libs": {
+						Name:        "custom-pkg-name",
+						Description: "Library files",
+						Artifacts: &dalec.Artifacts{
+							Binaries: map[string]dalec.ArtifactConfig{
+								"mybin": {},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	st := Debroot(ctx, dalec.SourceOpts{}, spec, llb.Scratch(), llb.Scratch(), "testdistro", "", "", SourcePkgConfig{})
+	def, err := st.Marshal(ctx)
+	assert.NilError(t, err)
+
+	// Should use the custom name, not "example-libs"
+	mkfile, err := findMkfile(t, def.ToPB(), filepath.Join("/debian", "custom-pkg-name.install"))
+	assert.NilError(t, err)
+	assert.Assert(t, mkfile != nil, "expected custom-pkg-name.install to be generated")
+	assert.Assert(t, cmp.Contains(string(mkfile.Data), "debian/custom-pkg-name"))
+
+	// Should NOT produce a file with the default name
+	mkfile2, err := findMkfile(t, def.ToPB(), filepath.Join("/debian", "example-libs.install"))
+	assert.NilError(t, err)
+	assert.Assert(t, mkfile2 == nil, "should not generate example-libs.install when custom name is set")
+}
+
+func TestDebrootSubPackagePostinst(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	spec := &dalec.Spec{
+		Name:        "example",
+		Description: "Example package",
+		Version:     "1.0.0",
+		Revision:    "1",
+		License:     "Apache-2.0",
+		Targets: map[string]dalec.Target{
+			"testdistro": {
+				Packages: map[string]dalec.SubPackage{
+					"svc": {
+						Description: "Service package",
+						Artifacts: &dalec.Artifacts{
+							Users: []dalec.AddUserConfig{
+								{Name: "svcuser"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	st := Debroot(ctx, dalec.SourceOpts{}, spec, llb.Scratch(), llb.Scratch(), "testdistro", "", "", SourcePkgConfig{})
+	def, err := st.Marshal(ctx)
+	assert.NilError(t, err)
+
+	// Subpackage should produce a postinst file with the resolved name
+	mkfile, err := findMkfile(t, def.ToPB(), filepath.Join("/debian", "example-svc.postinst"))
+	assert.NilError(t, err)
+	assert.Assert(t, mkfile != nil, "expected example-svc.postinst to be generated")
+	assert.Equal(t, int32(0o700), mkfile.Mode)
+	assert.Assert(t, bytes.Contains(mkfile.Data, []byte("#DEBHELPER#")))
+	assert.Assert(t, bytes.Contains(mkfile.Data, []byte("useradd svcuser")))
+}
+
+func TestDebrootSubPackageNoPostinstWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	spec := &dalec.Spec{
+		Name:        "example",
+		Description: "Example package",
+		Version:     "1.0.0",
+		Revision:    "1",
+		License:     "Apache-2.0",
+		Targets: map[string]dalec.Target{
+			"testdistro": {
+				Packages: map[string]dalec.SubPackage{
+					"libs": {
+						Description: "Library files",
+						Artifacts: &dalec.Artifacts{
+							Binaries: map[string]dalec.ArtifactConfig{
+								"mylib": {},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	st := Debroot(ctx, dalec.SourceOpts{}, spec, llb.Scratch(), llb.Scratch(), "testdistro", "", "", SourcePkgConfig{})
+	def, err := st.Marshal(ctx)
+	assert.NilError(t, err)
+
+	// Should NOT produce a postinst for a subpackage that has no users/groups/ownership
+	mkfile, err := findMkfile(t, def.ToPB(), filepath.Join("/debian", "example-libs.postinst"))
+	assert.NilError(t, err)
+	assert.Assert(t, mkfile == nil, "should not generate postinst for subpackage with no post-install actions")
+}
+
+func TestDebrootSubPackageDirsFile(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	spec := &dalec.Spec{
+		Name:        "example",
+		Description: "Example package",
+		Version:     "1.0.0",
+		Revision:    "1",
+		License:     "Apache-2.0",
+		Targets: map[string]dalec.Target{
+			"testdistro": {
+				Packages: map[string]dalec.SubPackage{
+					"data": {
+						Description: "Data package",
+						Artifacts: &dalec.Artifacts{
+							Directories: &dalec.CreateArtifactDirectories{
+								Config: map[string]dalec.ArtifactDirConfig{
+									"myapp": {},
+								},
+								State: map[string]dalec.ArtifactDirConfig{
+									"myapp": {},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	st := Debroot(ctx, dalec.SourceOpts{}, spec, llb.Scratch(), llb.Scratch(), "testdistro", "", "", SourcePkgConfig{})
+	def, err := st.Marshal(ctx)
+	assert.NilError(t, err)
+
+	mkfile, err := findMkfile(t, def.ToPB(), filepath.Join("/debian", "example-data.dirs"))
+	assert.NilError(t, err)
+	assert.Assert(t, mkfile != nil, "expected example-data.dirs to be generated")
+	assert.Assert(t, cmp.Contains(string(mkfile.Data), "/etc/myapp"))
+	assert.Assert(t, cmp.Contains(string(mkfile.Data), "/var/lib/myapp"))
+}
+
+func TestDebrootSubPackageLinksFile(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	spec := &dalec.Spec{
+		Name:        "example",
+		Description: "Example package",
+		Version:     "1.0.0",
+		Revision:    "1",
+		License:     "Apache-2.0",
+		Targets: map[string]dalec.Target{
+			"testdistro": {
+				Packages: map[string]dalec.SubPackage{
+					"compat": {
+						Description: "Compat symlinks",
+						Artifacts: &dalec.Artifacts{
+							Links: []dalec.ArtifactSymlinkConfig{
+								{Source: "/usr/bin/mybin", Dest: "/usr/bin/mybin-compat"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	st := Debroot(ctx, dalec.SourceOpts{}, spec, llb.Scratch(), llb.Scratch(), "testdistro", "", "", SourcePkgConfig{})
+	def, err := st.Marshal(ctx)
+	assert.NilError(t, err)
+
+	mkfile, err := findMkfile(t, def.ToPB(), filepath.Join("/debian", "example-compat.links"))
+	assert.NilError(t, err)
+	assert.Assert(t, mkfile != nil, "expected example-compat.links to be generated")
+	assert.Assert(t, cmp.Contains(string(mkfile.Data), "usr/bin/mybin"))
+	assert.Assert(t, cmp.Contains(string(mkfile.Data), "usr/bin/mybin-compat"))
+}
+
+func TestDebrootSubPackageFixPerms(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	spec := &dalec.Spec{
+		Name:        "example",
+		Description: "Example package",
+		Version:     "1.0.0",
+		Revision:    "1",
+		License:     "Apache-2.0",
+		Artifacts: dalec.Artifacts{
+			Binaries: map[string]dalec.ArtifactConfig{
+				"primarybin": {Permissions: 0o755},
+			},
+		},
+		Targets: map[string]dalec.Target{
+			"testdistro": {
+				Packages: map[string]dalec.SubPackage{
+					"tools": {
+						Description: "Extra tools",
+						Artifacts: &dalec.Artifacts{
+							Binaries: map[string]dalec.ArtifactConfig{
+								"subtool": {Permissions: 0o750},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	st := Debroot(ctx, dalec.SourceOpts{}, spec, llb.Scratch(), llb.Scratch(), "testdistro", "", "", SourcePkgConfig{})
+	def, err := st.Marshal(ctx)
+	assert.NilError(t, err)
+
+	mkfile, err := findMkfile(t, def.ToPB(), filepath.Join("/debian", "dalec/fix_perms.sh"))
+	assert.NilError(t, err)
+	assert.Assert(t, mkfile != nil, "expected fix_perms.sh to be generated")
+
+	content := string(mkfile.Data)
+	// Primary package permissions
+	assert.Assert(t, cmp.Contains(content, "debian/example"))
+	assert.Assert(t, cmp.Contains(content, "primarybin"))
+	// Subpackage permissions
+	assert.Assert(t, cmp.Contains(content, "debian/example-tools"))
+	assert.Assert(t, cmp.Contains(content, "subtool"))
+}
+
+func TestDebrootSubPackageDocsFile(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	spec := &dalec.Spec{
+		Name:        "example",
+		Description: "Example package",
+		Version:     "1.0.0",
+		Revision:    "1",
+		License:     "Apache-2.0",
+		Targets: map[string]dalec.Target{
+			"testdistro": {
+				Packages: map[string]dalec.SubPackage{
+					"doc": {
+						Description: "Documentation package",
+						Artifacts: &dalec.Artifacts{
+							Docs: map[string]dalec.ArtifactConfig{
+								"README.md": {},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	st := Debroot(ctx, dalec.SourceOpts{}, spec, llb.Scratch(), llb.Scratch(), "testdistro", "", "", SourcePkgConfig{})
+	def, err := st.Marshal(ctx)
+	assert.NilError(t, err)
+
+	mkfile, err := findMkfile(t, def.ToPB(), filepath.Join("/debian", "example-doc.docs"))
+	assert.NilError(t, err)
+	assert.Assert(t, mkfile != nil, "expected example-doc.docs to be generated")
+	assert.Assert(t, cmp.Contains(string(mkfile.Data), "README.md"))
+}
+
+func TestDebrootMultipleSubPackages(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	spec := &dalec.Spec{
+		Name:        "example",
+		Description: "Example package",
+		Version:     "1.0.0",
+		Revision:    "1",
+		License:     "Apache-2.0",
+		Targets: map[string]dalec.Target{
+			"testdistro": {
+				Packages: map[string]dalec.SubPackage{
+					"libs": {
+						Description: "Libraries",
+						Artifacts: &dalec.Artifacts{
+							Binaries: map[string]dalec.ArtifactConfig{
+								"lib-thing": {},
+							},
+						},
+					},
+					"tools": {
+						Description: "Tools",
+						Artifacts: &dalec.Artifacts{
+							Binaries: map[string]dalec.ArtifactConfig{
+								"extra-tool": {},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	st := Debroot(ctx, dalec.SourceOpts{}, spec, llb.Scratch(), llb.Scratch(), "testdistro", "", "", SourcePkgConfig{})
+	def, err := st.Marshal(ctx)
+	assert.NilError(t, err)
+
+	// Both subpackages should produce .install files
+	libsInstall, err := findMkfile(t, def.ToPB(), filepath.Join("/debian", "example-libs.install"))
+	assert.NilError(t, err)
+	assert.Assert(t, libsInstall != nil, "expected example-libs.install")
+	assert.Assert(t, cmp.Contains(string(libsInstall.Data), "lib-thing"))
+
+	toolsInstall, err := findMkfile(t, def.ToPB(), filepath.Join("/debian", "example-tools.install"))
+	assert.NilError(t, err)
+	assert.Assert(t, toolsInstall != nil, "expected example-tools.install")
+	assert.Assert(t, cmp.Contains(string(toolsInstall.Data), "extra-tool"))
+}
+
+func TestDebrootSubPackageControlFile(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	spec := &dalec.Spec{
+		Name:        "example",
+		Description: "Example package",
+		Version:     "1.0.0",
+		Revision:    "1",
+		License:     "Apache-2.0",
+		Targets: map[string]dalec.Target{
+			"testdistro": {
+				Packages: map[string]dalec.SubPackage{
+					"libs": {
+						Description: "Library files",
+						Dependencies: &dalec.SubPackageDependencies{
+							Runtime: dalec.PackageDependencyList{
+								"libfoo": dalec.PackageConstraints{},
+							},
+						},
+					},
+					"tools": {
+						Description: "Extra tools",
+					},
+				},
+			},
+		},
+	}
+
+	st := Debroot(ctx, dalec.SourceOpts{}, spec, llb.Scratch(), llb.Scratch(), "testdistro", "", "", SourcePkgConfig{})
+	def, err := st.Marshal(ctx)
+	assert.NilError(t, err)
+
+	mkfile, err := findMkfile(t, def.ToPB(), filepath.Join("/debian", "control"))
+	assert.NilError(t, err)
+	assert.Assert(t, mkfile != nil, "expected control file to be generated")
+
+	content := string(mkfile.Data)
+
+	// Primary package stanza should be present
+	assert.Assert(t, cmp.Contains(content, "Package:example"))
+
+	// Subpackage stanzas should be present
+	assert.Assert(t, cmp.Contains(content, "Package: example-libs"))
+	assert.Assert(t, cmp.Contains(content, "Package: example-tools"))
+
+	// Subpackage descriptions
+	assert.Assert(t, cmp.Contains(content, "Description: Library files"))
+	assert.Assert(t, cmp.Contains(content, "Description: Extra tools"))
+
+	// Runtime dep from subpackage
+	assert.Assert(t, cmp.Contains(content, "libfoo"))
+}
+
+func TestDebrootSubPackageRulesOverridePerms(t *testing.T) {
+	t.Parallel()
+
+	t.Run("subpackage perms triggers override", func(t *testing.T) {
+		ctx := context.Background()
+		// Primary has no custom perms, but subpackage does
+		spec := &dalec.Spec{
+			Name:        "example",
+			Description: "Example package",
+			Version:     "1.0.0",
+			Revision:    "1",
+			License:     "Apache-2.0",
+			Targets: map[string]dalec.Target{
+				"testdistro": {
+					Packages: map[string]dalec.SubPackage{
+						"tools": {
+							Description: "Extra tools",
+							Artifacts: &dalec.Artifacts{
+								Binaries: map[string]dalec.ArtifactConfig{
+									"subtool": {Permissions: 0o750},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		st := Debroot(ctx, dalec.SourceOpts{}, spec, llb.Scratch(), llb.Scratch(), "testdistro", "", "", SourcePkgConfig{})
+		def, err := st.Marshal(ctx)
+		assert.NilError(t, err)
+
+		mkfile, err := findMkfile(t, def.ToPB(), filepath.Join("/debian", "rules"))
+		assert.NilError(t, err)
+		assert.Assert(t, mkfile != nil)
+
+		content := string(mkfile.Data)
+		assert.Assert(t, cmp.Contains(content, "override_dh_fixperms"))
+		assert.Assert(t, cmp.Contains(content, "fix_perms.sh"))
+	})
+
+	t.Run("no perms no override", func(t *testing.T) {
+		ctx := context.Background()
+		spec := &dalec.Spec{
+			Name:        "example",
+			Description: "Example package",
+			Version:     "1.0.0",
+			Revision:    "1",
+			License:     "Apache-2.0",
+			Targets: map[string]dalec.Target{
+				"testdistro": {
+					Packages: map[string]dalec.SubPackage{
+						"tools": {
+							Description: "Extra tools",
+							Artifacts: &dalec.Artifacts{
+								Binaries: map[string]dalec.ArtifactConfig{
+									"subtool": {},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		st := Debroot(ctx, dalec.SourceOpts{}, spec, llb.Scratch(), llb.Scratch(), "testdistro", "", "", SourcePkgConfig{})
+		def, err := st.Marshal(ctx)
+		assert.NilError(t, err)
+
+		mkfile, err := findMkfile(t, def.ToPB(), filepath.Join("/debian", "rules"))
+		assert.NilError(t, err)
+		assert.Assert(t, mkfile != nil)
+
+		content := string(mkfile.Data)
+		assert.Assert(t, !bytes.Contains(mkfile.Data, []byte("override_dh_fixperms")), "should not contain fixperms override when no custom perms: %s", content)
+	})
+}
+
+func TestDebrootSubPackageRulesOverrideSystemd(t *testing.T) {
+	t.Parallel()
+
+	t.Run("subpackage units emits dh_installsystemd with package flag", func(t *testing.T) {
+		ctx := context.Background()
+		spec := &dalec.Spec{
+			Name:        "example",
+			Description: "Example package",
+			Version:     "1.0.0",
+			Revision:    "1",
+			License:     "Apache-2.0",
+			Targets: map[string]dalec.Target{
+				"testdistro": {
+					Packages: map[string]dalec.SubPackage{
+						"svc": {
+							Description: "Service package",
+							Artifacts: &dalec.Artifacts{
+								Systemd: &dalec.SystemdConfiguration{
+									Units: map[string]dalec.SystemdUnitConfig{
+										"mysvc.service": {Enable: true},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		st := Debroot(ctx, dalec.SourceOpts{}, spec, llb.Scratch(), llb.Scratch(), "testdistro", "", "", SourcePkgConfig{})
+		def, err := st.Marshal(ctx)
+		assert.NilError(t, err)
+
+		mkfile, err := findMkfile(t, def.ToPB(), filepath.Join("/debian", "rules"))
+		assert.NilError(t, err)
+		assert.Assert(t, mkfile != nil)
+
+		content := string(mkfile.Data)
+		assert.Assert(t, cmp.Contains(content, "override_dh_installsystemd"))
+		// Should use -p flag for subpackage
+		assert.Assert(t, cmp.Contains(content, "-pexample-svc"))
+		assert.Assert(t, cmp.Contains(content, "--name=mysvc"))
+	})
+
+	t.Run("primary and subpackage units both present", func(t *testing.T) {
+		ctx := context.Background()
+		spec := &dalec.Spec{
+			Name:        "example",
+			Description: "Example package",
+			Version:     "1.0.0",
+			Revision:    "1",
+			License:     "Apache-2.0",
+			Artifacts: dalec.Artifacts{
+				Systemd: &dalec.SystemdConfiguration{
+					Units: map[string]dalec.SystemdUnitConfig{
+						"primary.service": {Enable: true},
+					},
+				},
+			},
+			Targets: map[string]dalec.Target{
+				"testdistro": {
+					Packages: map[string]dalec.SubPackage{
+						"svc": {
+							Description: "Service package",
+							Artifacts: &dalec.Artifacts{
+								Systemd: &dalec.SystemdConfiguration{
+									Units: map[string]dalec.SystemdUnitConfig{
+										"subsvc.service": {Enable: false},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		st := Debroot(ctx, dalec.SourceOpts{}, spec, llb.Scratch(), llb.Scratch(), "testdistro", "", "", SourcePkgConfig{})
+		def, err := st.Marshal(ctx)
+		assert.NilError(t, err)
+
+		mkfile, err := findMkfile(t, def.ToPB(), filepath.Join("/debian", "rules"))
+		assert.NilError(t, err)
+		assert.Assert(t, mkfile != nil)
+
+		content := string(mkfile.Data)
+		// Primary unit: no -p flag
+		assert.Assert(t, cmp.Contains(content, "dh_installsystemd --name=primary\n"))
+		// Subpackage unit: -p flag, --no-enable
+		assert.Assert(t, cmp.Contains(content, "-pexample-svc --name=subsvc --no-enable"))
+	})
+}
+
+func TestDebrootSubPackageCustomSystemdPostinst(t *testing.T) {
+	t.Parallel()
+
+	t.Run("subpackage mixed enable generates custom postinst", func(t *testing.T) {
+		ctx := context.Background()
+		spec := &dalec.Spec{
+			Name:        "example",
+			Description: "Example package",
+			Version:     "1.0.0",
+			Revision:    "1",
+			License:     "Apache-2.0",
+			Targets: map[string]dalec.Target{
+				"testdistro": {
+					Packages: map[string]dalec.SubPackage{
+						"svc": {
+							Description: "Service package",
+							Artifacts: &dalec.Artifacts{
+								Systemd: &dalec.SystemdConfiguration{
+									Units: map[string]dalec.SystemdUnitConfig{
+										// Same basename "foo" with mixed enable — triggers custom enable
+										"foo.service": {Enable: true},
+										"foo.socket":  {Enable: false},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		st := Debroot(ctx, dalec.SourceOpts{}, spec, llb.Scratch(), llb.Scratch(), "testdistro", "", "", SourcePkgConfig{})
+		def, err := st.Marshal(ctx)
+		assert.NilError(t, err)
+
+		// The subpackage's custom-enable snippet must be written to its own
+		// per-package partial (keyed by resolved name), not the primary partial,
+		// so it can be appended to the subpackage's own maintainer script.
+		subPartial := filepath.Join("/debian", "dalec/example-svc."+customSystemdPostinstFile)
+		mkfile, err := findMkfile(t, def.ToPB(), subPartial)
+		assert.NilError(t, err)
+		assert.Assert(t, mkfile != nil, "expected per-subpackage custom systemd postinst partial to be generated for subpackage with mixed enable")
+
+		content := string(mkfile.Data)
+		assert.Assert(t, cmp.Contains(content, "foo.service"))
+		assert.Assert(t, cmp.Contains(content, "foo.socket"))
+
+		// The primary partial must NOT be generated since the primary package has
+		// no units; the subpackage's units must not leak into it.
+		primaryPartial := filepath.Join("/debian", "dalec/"+customSystemdPostinstFile)
+		primaryFile, err := findMkfile(t, def.ToPB(), primaryPartial)
+		assert.NilError(t, err)
+		assert.Assert(t, primaryFile == nil, "subpackage units must not be routed into the primary custom systemd postinst partial")
+	})
+
+	t.Run("no mixed enable no custom postinst file", func(t *testing.T) {
+		ctx := context.Background()
+		spec := &dalec.Spec{
+			Name:        "example",
+			Description: "Example package",
+			Version:     "1.0.0",
+			Revision:    "1",
+			License:     "Apache-2.0",
+			Targets: map[string]dalec.Target{
+				"testdistro": {
+					Packages: map[string]dalec.SubPackage{
+						"svc": {
+							Description: "Service package",
+							Artifacts: &dalec.Artifacts{
+								Systemd: &dalec.SystemdConfiguration{
+									Units: map[string]dalec.SystemdUnitConfig{
+										"bar.service": {Enable: true},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		st := Debroot(ctx, dalec.SourceOpts{}, spec, llb.Scratch(), llb.Scratch(), "testdistro", "", "", SourcePkgConfig{})
+		def, err := st.Marshal(ctx)
+		assert.NilError(t, err)
+
+		mkfile, err := findMkfile(t, def.ToPB(), filepath.Join("/debian", "dalec/"+customSystemdPostinstFile))
+		assert.NilError(t, err)
+		assert.Assert(t, mkfile == nil, "should not generate custom systemd postinst when no mixed enable")
+	})
+}
+
+func TestDebrootSubPackageWrongTarget(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	spec := &dalec.Spec{
+		Name:        "example",
+		Description: "Example package",
+		Version:     "1.0.0",
+		Revision:    "1",
+		License:     "Apache-2.0",
+		Targets: map[string]dalec.Target{
+			"otherdistro": {
+				Packages: map[string]dalec.SubPackage{
+					"libs": {
+						Description: "Library files",
+						Artifacts: &dalec.Artifacts{
+							Binaries: map[string]dalec.ArtifactConfig{
+								"mylib": {},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Build for "testdistro" but packages are defined under "otherdistro"
+	st := Debroot(ctx, dalec.SourceOpts{}, spec, llb.Scratch(), llb.Scratch(), "testdistro", "", "", SourcePkgConfig{})
+	def, err := st.Marshal(ctx)
+	assert.NilError(t, err)
+
+	// Should NOT produce any subpackage files for a different target
+	mkfile, err := findMkfile(t, def.ToPB(), filepath.Join("/debian", "example-libs.install"))
+	assert.NilError(t, err)
+	assert.Assert(t, mkfile == nil, "should not generate subpackage files for wrong target")
+}

--- a/packaging/linux/deb/template_control.go
+++ b/packaging/linux/deb/template_control.go
@@ -220,6 +220,107 @@ func (w *controlWrapper) Provides() fmt.Stringer {
 	return b
 }
 
+func (w *controlWrapper) SubPackages() fmt.Stringer {
+	b := &strings.Builder{}
+
+	packages := w.Spec.GetSubPackages(w.Target)
+	if len(packages) == 0 {
+		return b
+	}
+
+	artifacts := w.Spec.GetArtifacts(w.Target)
+
+	// Separate the primary package stanza from the first subpackage stanza with a
+	// blank line. Debian control paragraphs must be blank-line separated;
+	// without this, dpkg parses the subpackage fields as part of the primary
+	// stanza and fails (duplicate "Package" field).
+	b.WriteString("\n")
+
+	keys := dalec.SortMapKeys(packages)
+	for _, key := range keys {
+		pkg := packages[key]
+		resolvedName := pkg.ResolvedName(w.Spec.Name, key)
+		w.writeSubPackageStanza(b, resolvedName, &pkg, artifacts.DisableAutoRequires)
+	}
+
+	return b
+}
+
+func (w *controlWrapper) writeSubPackageStanza(b *strings.Builder, resolvedName string, pkg *dalec.SubPackage, disableAutoRequires bool) {
+	fmt.Fprintf(b, "Package: %s\n", resolvedName)
+	fmt.Fprintf(b, "Architecture: %s\n", w.Architecture())
+	fmt.Fprintln(b, "Section: -")
+
+	w.subPackageDepends(b, pkg, disableAutoRequires)
+	w.subPackageRecommends(b, pkg)
+
+	if len(pkg.Replaces) > 0 {
+		ls := AppendConstraints(pkg.Replaces)
+		fmt.Fprintln(b, multiline("Replaces", ls))
+	}
+
+	if len(pkg.Conflicts) > 0 {
+		ls := AppendConstraints(pkg.Conflicts)
+		fmt.Fprintln(b, multiline("Conflicts", ls))
+	}
+
+	if len(pkg.Provides) > 0 {
+		ls := AppendConstraints(pkg.Provides)
+		fmt.Fprintln(b, multiline("Provides", ls))
+	}
+
+	if pkg.Description != "" {
+		fmt.Fprintf(b, "Description: %s\n", pkg.Description)
+	}
+	fmt.Fprintln(b)
+}
+
+func (w *controlWrapper) subPackageDepends(b *strings.Builder, pkg *dalec.SubPackage, disableAutoRequires bool) {
+	const (
+		shlibsDeps = "${shlibs:Depends}"
+		miscDeps   = "${misc:Depends}"
+	)
+
+	rtDeps := pkg.Dependencies.GetRuntime()
+	needsClone := rtDeps != nil
+
+	if !disableAutoRequires {
+		if _, exists := rtDeps[shlibsDeps]; !exists {
+			if needsClone {
+				rtDeps = maps.Clone(rtDeps)
+				needsClone = false
+			}
+			if rtDeps == nil {
+				rtDeps = make(dalec.PackageDependencyList)
+			}
+			rtDeps[shlibsDeps] = dalec.PackageConstraints{}
+		}
+	}
+
+	if _, exists := rtDeps[miscDeps]; !exists {
+		if needsClone {
+			rtDeps = maps.Clone(rtDeps)
+		}
+		if rtDeps == nil {
+			rtDeps = make(dalec.PackageDependencyList)
+		}
+		rtDeps[miscDeps] = dalec.PackageConstraints{}
+	}
+
+	deps := AppendConstraints(rtDeps)
+	fmt.Fprintln(b, multiline("Depends", deps))
+}
+
+func (w *controlWrapper) subPackageRecommends(b *strings.Builder, pkg *dalec.SubPackage) {
+	recommends := pkg.Dependencies.GetRecommends()
+	if len(recommends) == 0 {
+		return
+	}
+
+	deps := AppendConstraints(recommends)
+	fmt.Fprintln(b, multiline("Recommends", deps))
+}
+
 var (
 	//go:embed templates/debian_control.tmpl
 	controlTmplContent []byte

--- a/packaging/linux/deb/template_control_test.go
+++ b/packaging/linux/deb/template_control_test.go
@@ -305,3 +305,266 @@ func TestControlWrapper_ReplacesConflictsProvides(t *testing.T) {
 		assert.Assert(t, cmp.Contains(deps.String(), "${shlibs:Depends}"))
 	})
 }
+
+func TestControlWrapper_SubPackages(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no subpackages", func(t *testing.T) {
+		spec := &dalec.Spec{
+			Name:    "test-pkg",
+			Version: "1.0.0",
+		}
+		wrapper := &controlWrapper{spec, "target1"}
+		assert.Equal(t, wrapper.SubPackages().String(), "")
+	})
+
+	t.Run("wrong target", func(t *testing.T) {
+		spec := &dalec.Spec{
+			Name:    "test-pkg",
+			Version: "1.0.0",
+			Targets: map[string]dalec.Target{
+				"target1": {
+					Packages: map[string]dalec.SubPackage{
+						"libs": {Description: "Library files"},
+					},
+				},
+			},
+		}
+		wrapper := &controlWrapper{spec, "non-existent"}
+		assert.Equal(t, wrapper.SubPackages().String(), "")
+	})
+
+	t.Run("single subpackage default name", func(t *testing.T) {
+		spec := &dalec.Spec{
+			Name:    "test-pkg",
+			Version: "1.0.0",
+			Targets: map[string]dalec.Target{
+				"target1": {
+					Packages: map[string]dalec.SubPackage{
+						"libs": {Description: "Library files"},
+					},
+				},
+			},
+		}
+		wrapper := &controlWrapper{spec, "target1"}
+		result := wrapper.SubPackages().String()
+
+		assert.Assert(t, cmp.Contains(result, "Package: test-pkg-libs"))
+		assert.Assert(t, cmp.Contains(result, "Architecture: linux-any"))
+		assert.Assert(t, cmp.Contains(result, "Section: -"))
+		assert.Assert(t, cmp.Contains(result, "Description: Library files"))
+		// Should include misc:Depends and shlibs:Depends by default
+		assert.Assert(t, cmp.Contains(result, "${misc:Depends}"))
+		assert.Assert(t, cmp.Contains(result, "${shlibs:Depends}"))
+	})
+
+	t.Run("single subpackage custom name", func(t *testing.T) {
+		spec := &dalec.Spec{
+			Name:    "test-pkg",
+			Version: "1.0.0",
+			Targets: map[string]dalec.Target{
+				"target1": {
+					Packages: map[string]dalec.SubPackage{
+						"libs": {
+							Name:        "custom-libs-name",
+							Description: "Custom library files",
+						},
+					},
+				},
+			},
+		}
+		wrapper := &controlWrapper{spec, "target1"}
+		result := wrapper.SubPackages().String()
+
+		assert.Assert(t, cmp.Contains(result, "Package: custom-libs-name"))
+		assert.Assert(t, !strings.Contains(result, "test-pkg-libs"))
+	})
+
+	t.Run("noarch architecture", func(t *testing.T) {
+		spec := &dalec.Spec{
+			Name:    "test-pkg",
+			Version: "1.0.0",
+			NoArch:  true,
+			Targets: map[string]dalec.Target{
+				"target1": {
+					Packages: map[string]dalec.SubPackage{
+						"data": {Description: "Data files"},
+					},
+				},
+			},
+		}
+		wrapper := &controlWrapper{spec, "target1"}
+		result := wrapper.SubPackages().String()
+
+		assert.Assert(t, cmp.Contains(result, "Architecture: all"))
+	})
+
+	t.Run("subpackage with dependencies", func(t *testing.T) {
+		spec := &dalec.Spec{
+			Name:    "test-pkg",
+			Version: "1.0.0",
+			Targets: map[string]dalec.Target{
+				"target1": {
+					Packages: map[string]dalec.SubPackage{
+						"libs": {
+							Description: "Library files",
+							Dependencies: &dalec.SubPackageDependencies{
+								Runtime: dalec.PackageDependencyList{
+									"libfoo": dalec.PackageConstraints{Version: []string{">= 1.0"}},
+									"libbar": dalec.PackageConstraints{},
+								},
+								Recommends: dalec.PackageDependencyList{
+									"suggested-pkg": dalec.PackageConstraints{},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		wrapper := &controlWrapper{spec, "target1"}
+		result := wrapper.SubPackages().String()
+
+		assert.Assert(t, cmp.Contains(result, "libbar"))
+		assert.Assert(t, cmp.Contains(result, "libfoo (>= 1.0)"))
+		assert.Assert(t, cmp.Contains(result, "${misc:Depends}"))
+		assert.Assert(t, cmp.Contains(result, "Recommends: suggested-pkg"))
+	})
+
+	t.Run("subpackage with conflicts replaces provides", func(t *testing.T) {
+		spec := &dalec.Spec{
+			Name:    "test-pkg",
+			Version: "1.0.0",
+			Targets: map[string]dalec.Target{
+				"target1": {
+					Packages: map[string]dalec.SubPackage{
+						"libs": {
+							Description: "Library files",
+							Conflicts: dalec.PackageDependencyList{
+								"old-libs": dalec.PackageConstraints{Version: []string{"<< 2.0"}},
+							},
+							Replaces: dalec.PackageDependencyList{
+								"old-libs": dalec.PackageConstraints{Version: []string{"<< 2.0"}},
+							},
+							Provides: dalec.PackageDependencyList{
+								"libs-api": dalec.PackageConstraints{},
+							},
+						},
+					},
+				},
+			},
+		}
+		wrapper := &controlWrapper{spec, "target1"}
+		result := wrapper.SubPackages().String()
+
+		assert.Assert(t, cmp.Contains(result, "Conflicts: old-libs (<< 2.0)"))
+		assert.Assert(t, cmp.Contains(result, "Replaces: old-libs (<< 2.0)"))
+		assert.Assert(t, cmp.Contains(result, "Provides: libs-api"))
+	})
+
+	t.Run("disable auto requires suppresses shlibs", func(t *testing.T) {
+		spec := &dalec.Spec{
+			Name:    "test-pkg",
+			Version: "1.0.0",
+			Targets: map[string]dalec.Target{
+				"target1": {
+					Artifacts: &dalec.Artifacts{
+						DisableAutoRequires: true,
+					},
+					Packages: map[string]dalec.SubPackage{
+						"libs": {Description: "Library files"},
+					},
+				},
+			},
+		}
+		wrapper := &controlWrapper{spec, "target1"}
+		result := wrapper.SubPackages().String()
+
+		assert.Assert(t, !strings.Contains(result, "${shlibs:Depends}"))
+		assert.Assert(t, cmp.Contains(result, "${misc:Depends}"))
+	})
+
+	t.Run("multiple subpackages sorted", func(t *testing.T) {
+		spec := &dalec.Spec{
+			Name:    "test-pkg",
+			Version: "1.0.0",
+			Targets: map[string]dalec.Target{
+				"target1": {
+					Packages: map[string]dalec.SubPackage{
+						"zeta": {Description: "Zeta package"},
+						"alpha": {
+							Description: "Alpha package",
+							Dependencies: &dalec.SubPackageDependencies{
+								Runtime: dalec.PackageDependencyList{
+									"dep-a": dalec.PackageConstraints{},
+								},
+							},
+						},
+						"beta": {Description: "Beta package"},
+					},
+				},
+			},
+		}
+		wrapper := &controlWrapper{spec, "target1"}
+		result := wrapper.SubPackages().String()
+
+		// All three should be present
+		assert.Assert(t, cmp.Contains(result, "Package: test-pkg-alpha"))
+		assert.Assert(t, cmp.Contains(result, "Package: test-pkg-beta"))
+		assert.Assert(t, cmp.Contains(result, "Package: test-pkg-zeta"))
+
+		// Alpha should appear before beta which should appear before zeta
+		alphaIdx := strings.Index(result, "Package: test-pkg-alpha")
+		betaIdx := strings.Index(result, "Package: test-pkg-beta")
+		zetaIdx := strings.Index(result, "Package: test-pkg-zeta")
+		assert.Assert(t, alphaIdx < betaIdx)
+		assert.Assert(t, betaIdx < zetaIdx)
+	})
+
+	t.Run("full WriteControl with subpackages", func(t *testing.T) {
+		spec := &dalec.Spec{
+			Name:        "test-pkg",
+			Version:     "1.0.0",
+			Description: "Main package",
+			Targets: map[string]dalec.Target{
+				"target1": {
+					Packages: map[string]dalec.SubPackage{
+						"libs": {
+							Description: "Library files",
+							Dependencies: &dalec.SubPackageDependencies{
+								Runtime: dalec.PackageDependencyList{
+									"libfoo": dalec.PackageConstraints{},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		buf := &strings.Builder{}
+		err := WriteControl(spec, "target1", buf)
+		assert.NilError(t, err)
+		result := buf.String()
+
+		// Primary package stanza (template uses {{- .Name -}} which strips the space)
+		assert.Assert(t, cmp.Contains(result, "Source:test-pkg"))
+		assert.Assert(t, cmp.Contains(result, "Package:test-pkg\n"))
+		assert.Assert(t, cmp.Contains(result, "Description: Main package"))
+
+		// Subpackage stanza
+		assert.Assert(t, cmp.Contains(result, "Package: test-pkg-libs"))
+		assert.Assert(t, cmp.Contains(result, "Description: Library files"))
+		assert.Assert(t, cmp.Contains(result, "libfoo"))
+
+		// Subpackage stanza appears after primary
+		primaryIdx := strings.Index(result, "Package:test-pkg\n")
+		subIdx := strings.Index(result, "Package: test-pkg-libs")
+		assert.Assert(t, primaryIdx < subIdx)
+
+		// Debian control paragraphs must be separated by a blank line, otherwise
+		// dpkg parses the subpackage fields as part of the primary stanza and
+		// fails with a duplicate "Package" field.
+		assert.Assert(t, cmp.Contains(result, "Description: Main package\n\nPackage: test-pkg-libs"))
+	})
+}

--- a/packaging/linux/deb/template_custom_dh_installsystemd_postinst.go
+++ b/packaging/linux/deb/template_custom_dh_installsystemd_postinst.go
@@ -23,19 +23,93 @@ var (
 	customStartTmpl    = template.Must(template.New("start").Parse(string(customStartTmplContent)))
 )
 
+// customSystemdPartial holds the generated custom-enable postinst snippet for a
+// single package (primary or subpackage). The snippet must be appended to that
+// package's own maintainer script so that units ship and enable in the same
+// package.
+type customSystemdPartial struct {
+	// pkgName is the resolved package name that owns the units.
+	pkgName string
+	// isPrimary is true for the primary package.
+	isPrimary bool
+	// content is the custom-enable postinst snippet.
+	content []byte
+}
+
+// partialFile returns the filename (under debian/dalec/) the snippet is written to.
+func (p customSystemdPartial) partialFile() string {
+	if p.isPrimary {
+		return customSystemdPostinstFile
+	}
+	return p.pkgName + "." + customSystemdPostinstFile
+}
+
+// postinstTarget returns the maintainer script the snippet must be appended to.
+func (p customSystemdPartial) postinstTarget() string {
+	if p.isPrimary {
+		return "debian/postinst"
+	}
+	return "debian/" + p.pkgName + ".postinst"
+}
+
 // This is used to generate a postinst (or at least part of a postinst) for the
 // case where we have a mix of enabled/disabled units with the same basename.
 // For all units that need this, the `dh_installsystemd` command should be
 // executed with the `--no-enable` option.
 // This handles enabled or not enabled for this special case instead of using
 // the postinst provided by `dh_installsystemd` without `--no-eable` set.
-func customDHInstallSystemdPostinst(spec *dalec.Spec, target string) ([]byte, error) {
+//
+// A snippet is generated per package (primary and each subpackage) so that each
+// snippet can be appended to the maintainer script of the package that actually
+// ships the units, rather than always landing in the primary package's postinst.
+func customDHInstallSystemdPostinst(spec *dalec.Spec, target string) ([]customSystemdPartial, error) {
+	var partials []customSystemdPartial
+
+	// Primary package units
 	artifacts := spec.GetArtifacts(target)
-	units := artifacts.Systemd.GetUnits()
-	grouped := groupUnitsByBaseName(units)
-
 	buf := bytes.NewBuffer(nil)
+	if err := writeCustomEnableForUnits(buf, artifacts.Systemd.GetUnits()); err != nil {
+		return nil, err
+	}
+	if buf.Len() > 0 {
+		partials = append(partials, customSystemdPartial{
+			pkgName:   spec.Name,
+			isPrimary: true,
+			content:   buf.Bytes(),
+		})
+	}
 
+	// Subpackage units — each gets its own snippet keyed by resolved name.
+	packages := spec.GetSubPackages(target)
+	if len(packages) > 0 {
+		keys := dalec.SortMapKeys(packages)
+		for _, key := range keys {
+			pkg := packages[key]
+			if pkg.Artifacts == nil {
+				continue
+			}
+			subBuf := bytes.NewBuffer(nil)
+			if err := writeCustomEnableForUnits(subBuf, pkg.Artifacts.Systemd.GetUnits()); err != nil {
+				return nil, errors.Wrapf(err, "subpackage %s", key)
+			}
+			if subBuf.Len() > 0 {
+				partials = append(partials, customSystemdPartial{
+					pkgName: pkg.ResolvedName(spec.Name, key),
+					content: subBuf.Bytes(),
+				})
+			}
+		}
+	}
+
+	return partials, nil
+}
+
+func writeCustomEnableForUnits(buf *bytes.Buffer, units map[string]dalec.SystemdUnitConfig) error {
+	if len(units) == 0 {
+		return nil
+	}
+
+	grouped := groupUnitsByBaseName(units)
 	sorted := dalec.SortMapKeys(grouped)
 	for _, v := range sorted {
 		ls := grouped[v]
@@ -43,20 +117,19 @@ func customDHInstallSystemdPostinst(spec *dalec.Spec, target string) ([]byte, er
 			continue
 		}
 
-		sorted := dalec.SortMapKeys(ls)
-
-		for _, name := range sorted {
+		sortedNames := dalec.SortMapKeys(ls)
+		for _, name := range sortedNames {
 			cfg := ls[name]
 			if err := writeCustomEnablePartial(buf, name, &cfg); err != nil {
-				return nil, errors.Wrapf(err, "error writing custom systemd enable template for unit: %s", name)
+				return errors.Wrapf(err, "error writing custom systemd enable template for unit: %s", name)
 			}
 			if err := customStartTmpl.Execute(buf, name); err != nil {
-				return nil, errors.Wrapf(err, "error writing custom systemd start template for unit: %s", name)
+				return errors.Wrapf(err, "error writing custom systemd start template for unit: %s", name)
 			}
 		}
 	}
 
-	return buf.Bytes(), nil
+	return nil
 }
 
 func writeCustomEnablePartial(buf io.Writer, name string, cfg *dalec.SystemdUnitConfig) error {

--- a/packaging/linux/deb/template_rules.go
+++ b/packaging/linux/deb/template_rules.go
@@ -74,9 +74,6 @@ func (w *rulesWrapper) Envs() fmt.Stringer {
 func (w *rulesWrapper) OverridePerms() fmt.Stringer {
 	b := &strings.Builder{}
 
-	artifacts := w.GetArtifacts(w.target)
-
-	var fixPerms bool
 	checkPerms := func(cfgs map[string]dalec.ArtifactConfig) bool {
 		for _, cfg := range cfgs {
 			if cfg.Permissions.Perm() != 0 {
@@ -95,17 +92,36 @@ func (w *rulesWrapper) OverridePerms() fmt.Stringer {
 		return false
 	}
 
-	fixPerms = checkPerms(artifacts.Binaries) ||
-		checkPerms(artifacts.ConfigFiles) ||
-		checkPerms(artifacts.Manpages) ||
-		checkPerms(artifacts.Headers) ||
-		checkPerms(artifacts.Licenses) ||
-		checkPerms(artifacts.Docs) ||
-		checkPerms(artifacts.Libs) ||
-		checkPerms(artifacts.Libexec) ||
-		checkPerms(artifacts.DataDirs) ||
-		checkDirPerms(artifacts.Directories.GetConfig()) ||
-		checkDirPerms(artifacts.Directories.GetState())
+	checkArtifactPerms := func(artifacts *dalec.Artifacts) bool {
+		if artifacts == nil {
+			return false
+		}
+		return checkPerms(artifacts.Binaries) ||
+			checkPerms(artifacts.ConfigFiles) ||
+			checkPerms(artifacts.Manpages) ||
+			checkPerms(artifacts.Headers) ||
+			checkPerms(artifacts.Licenses) ||
+			checkPerms(artifacts.Docs) ||
+			checkPerms(artifacts.Libs) ||
+			checkPerms(artifacts.Libexec) ||
+			checkPerms(artifacts.DataDirs) ||
+			checkDirPerms(artifacts.Directories.GetConfig()) ||
+			checkDirPerms(artifacts.Directories.GetState())
+	}
+
+	artifacts := w.GetArtifacts(w.target)
+	fixPerms := checkArtifactPerms(&artifacts)
+
+	// Also check subpackage artifacts
+	if !fixPerms {
+		packages := w.Spec.GetSubPackages(w.target)
+		for _, pkg := range packages {
+			if checkArtifactPerms(pkg.Artifacts) {
+				fixPerms = true
+				break
+			}
+		}
+	}
 
 	if fixPerms {
 		// Normally this should be `execute_after_dh_fixperms`, however this doesn't
@@ -114,7 +130,7 @@ func (w *rulesWrapper) OverridePerms() fmt.Stringer {
 		// our extra script.
 		b.WriteString("override_dh_fixperms:\n")
 		b.WriteString("\tdh_fixperms\n")
-		b.WriteString("\tDESTDIR=debian/$(shell dh_listpackages) debian/dalec/fix_perms.sh\n\n")
+		b.WriteString("\tdebian/dalec/fix_perms.sh\n\n")
 	}
 
 	return b
@@ -140,54 +156,112 @@ func (w *rulesWrapper) OverrideSystemd() (fmt.Stringer, error) {
 	b := &strings.Builder{}
 
 	artifacts := w.GetArtifacts(w.target)
-
 	units := artifacts.Systemd.GetUnits()
 
-	if len(units) == 0 {
+	// Collect subpackage units
+	type pkgUnits struct {
+		pkgName string
+		units   map[string]dalec.SystemdUnitConfig
+	}
+	var subPkgUnits []pkgUnits
+
+	packages := w.Spec.GetSubPackages(w.target)
+	if len(packages) > 0 {
+		keys := dalec.SortMapKeys(packages)
+		for _, key := range keys {
+			pkg := packages[key]
+			if pkg.Artifacts == nil {
+				continue
+			}
+			subUnits := pkg.Artifacts.Systemd.GetUnits()
+			if len(subUnits) > 0 {
+				subPkgUnits = append(subPkgUnits, pkgUnits{
+					pkgName: pkg.ResolvedName(w.Spec.Name, key),
+					units:   subUnits,
+				})
+			}
+		}
+	}
+
+	if len(units) == 0 && len(subPkgUnits) == 0 {
 		return b, nil
 	}
 
 	b.WriteString("override_dh_installsystemd:\n")
 
-	grouped := groupUnitsByBaseName(units)
-	sorted := dalec.SortMapKeys(grouped)
+	// Track which packages need a custom-enable snippet appended to their own
+	// maintainer script. The snippet for a package's units must land in that
+	// package's postinst, not always in the primary package's postinst.
+	var customEnablePartials []customSystemdPartial
 
-	var includeCustomEnable bool
-	for _, basename := range sorted {
-		grouping := grouped[basename]
+	// Primary package units
+	if len(units) > 0 {
+		grouped := groupUnitsByBaseName(units)
+		sorted := dalec.SortMapKeys(grouped)
 
-		needsCustomEnable := requiresCustomEnable(grouping)
-		if needsCustomEnable {
-			includeCustomEnable = true
+		var primaryNeedsCustom bool
+		for _, basename := range sorted {
+			grouping := grouped[basename]
+
+			needsCustomEnable := requiresCustomEnable(grouping)
+			if needsCustomEnable {
+				primaryNeedsCustom = true
+			}
+
+			firstKey := maps.Keys(grouping)[0]
+			enable := grouping[firstKey].Enable
+
+			b.WriteString("\tdh_installsystemd --name=" + basename)
+			if !enable || needsCustomEnable {
+				b.WriteString(" --no-enable")
+			}
+			b.WriteString("\n")
 		}
 
-		// dh_installsystemd does not want the suffix of the file, so trim it off
-		// here.
-		// Otherwise it will _silently_ fail, *yay*.
-		// We also need to check if there are multiple units with the same base name
-		// with different `Enable` options set.
-		// `dh_installsystemd` cannot deal with this, in those cases we'll write a
-		// custom postinst/postrm script.
-		//
-		// We also only need to do this once per basename, so we don't need to
-		// iterate over every unit.
-
-		// Get the first key which we'll use to check if the unit is enabled.
-		// Either all units are enabled or not enabled OR we need to do custom enable
-		firstKey := maps.Keys(grouping)[0]
-		enable := grouping[firstKey].Enable
-
-		b.WriteString("\tdh_installsystemd --name=" + basename)
-		if !enable || needsCustomEnable {
-			b.WriteString(" --no-enable")
+		if primaryNeedsCustom {
+			customEnablePartials = append(customEnablePartials, customSystemdPartial{
+				pkgName:   w.Spec.Name,
+				isPrimary: true,
+			})
 		}
-		b.WriteString("\n")
 	}
 
-	if includeCustomEnable {
-		b.WriteString("\t[ -f debian/postinst ] || (echo '#!/bin/sh' > debian/postinst; echo 'set -e' >> debian/postinst)\n")
-		b.WriteString("\t[ -x debian/postinst ] || chmod +x debian/postinst\n")
-		b.WriteString("\tcat debian/dalec/" + customSystemdPostinstFile + " >> debian/postinst\n")
+	// Subpackage units
+	for _, su := range subPkgUnits {
+		grouped := groupUnitsByBaseName(su.units)
+		sorted := dalec.SortMapKeys(grouped)
+
+		var subNeedsCustom bool
+		for _, basename := range sorted {
+			grouping := grouped[basename]
+
+			needsCustomEnable := requiresCustomEnable(grouping)
+			if needsCustomEnable {
+				subNeedsCustom = true
+			}
+
+			firstKey := maps.Keys(grouping)[0]
+			enable := grouping[firstKey].Enable
+
+			b.WriteString("\tdh_installsystemd -p" + su.pkgName + " --name=" + basename)
+			if !enable || needsCustomEnable {
+				b.WriteString(" --no-enable")
+			}
+			b.WriteString("\n")
+		}
+
+		if subNeedsCustom {
+			customEnablePartials = append(customEnablePartials, customSystemdPartial{
+				pkgName: su.pkgName,
+			})
+		}
+	}
+
+	for _, partial := range customEnablePartials {
+		target := partial.postinstTarget()
+		b.WriteString("\t[ -f " + target + " ] || (echo '#!/bin/sh' > " + target + "; echo 'set -e' >> " + target + ")\n")
+		b.WriteString("\t[ -x " + target + " ] || chmod +x " + target + "\n")
+		b.WriteString("\tcat debian/dalec/" + partial.partialFile() + " >> " + target + "\n")
 	}
 
 	return b, nil

--- a/packaging/linux/deb/template_rules_test.go
+++ b/packaging/linux/deb/template_rules_test.go
@@ -110,6 +110,42 @@ func TestRules_OverrideSystemd(t *testing.T) {
 			assert.Equal(t, out.String(), expect)
 		})
 	})
+
+	t.Run("subpackage mixed enable routes custom enable to subpackage postinst", func(t *testing.T) {
+		w := &rulesWrapper{
+			Spec: &dalec.Spec{
+				Name: "example",
+				Targets: map[string]dalec.Target{
+					"testdistro": {
+						Packages: map[string]dalec.SubPackage{
+							"svc": {
+								Description: "Service package",
+								Artifacts: &dalec.Artifacts{
+									Systemd: &dalec.SystemdConfiguration{
+										Units: map[string]dalec.SystemdUnitConfig{
+											"foo.service": {Enable: true},
+											"foo.socket":  {Enable: false},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			target: "testdistro",
+		}
+
+		out, err := w.OverrideSystemd()
+		assert.NilError(t, err)
+		expect := `override_dh_installsystemd:
+	dh_installsystemd -pexample-svc --name=foo --no-enable
+	[ -f debian/example-svc.postinst ] || (echo '#!/bin/sh' > debian/example-svc.postinst; echo 'set -e' >> debian/example-svc.postinst)
+	[ -x debian/example-svc.postinst ] || chmod +x debian/example-svc.postinst
+	cat debian/dalec/example-svc.custom_systemd_postinst.sh.partial >> debian/example-svc.postinst
+`
+		assert.Equal(t, out.String(), expect)
+	})
 }
 
 func TestDepends(t *testing.T) {

--- a/packaging/linux/deb/templates/debian_control.tmpl
+++ b/packaging/linux/deb/templates/debian_control.tmpl
@@ -11,3 +11,4 @@ Section: -
 {{.Conflicts -}}
 {{.Provides -}}
 {{if .Description}}Description: {{.Description}}{{end}}
+{{ .SubPackages }}

--- a/packaging/linux/rpm/buildroot_test.go
+++ b/packaging/linux/rpm/buildroot_test.go
@@ -1,0 +1,334 @@
+package rpm
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/project-dalec/dalec"
+	"github.com/project-dalec/dalec/internal/test"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+// findSpecMkfile iterates over all LLB ops and returns the path and data of the
+// first Mkfile action whose path ends in ".spec".
+func findSpecMkfile(t *testing.T, ops []test.LLBOp) (path string, data string) {
+	t.Helper()
+	for _, op := range ops {
+		f := op.Op.GetFile()
+		if f == nil {
+			continue
+		}
+		for _, a := range f.Actions {
+			mkfile := a.GetMkfile()
+			if mkfile == nil {
+				continue
+			}
+			if strings.HasSuffix(mkfile.Path, ".spec") {
+				return mkfile.Path, string(mkfile.Data)
+			}
+		}
+	}
+	t.Fatal("no Mkfile action with .spec path found in LLB ops")
+	return "", ""
+}
+
+// findMkdir iterates over all LLB ops and returns the path of the first Mkdir action.
+func findMkdir(t *testing.T, ops []test.LLBOp) string {
+	t.Helper()
+	for _, op := range ops {
+		f := op.Op.GetFile()
+		if f == nil {
+			continue
+		}
+		for _, a := range f.Actions {
+			mkdir := a.GetMkdir()
+			if mkdir == nil {
+				continue
+			}
+			return mkdir.Path
+		}
+	}
+	t.Fatal("no Mkdir action found in LLB ops")
+	return ""
+}
+
+// baseSpec returns a minimal valid spec suitable for RPMSpec().
+func baseSpec(name string) *dalec.Spec {
+	return &dalec.Spec{
+		Name:        name,
+		Version:     "1.0.0",
+		Revision:    "1",
+		Description: "Test package",
+		License:     "MIT",
+	}
+}
+
+func TestRPMSpec_LLB(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("directory_and_filename", func(t *testing.T) {
+		t.Parallel()
+		spec := baseSpec("myapp")
+
+		state := RPMSpec(spec, llb.Scratch(), "", "")
+		ops, err := test.LLBOpsFromState(ctx, state)
+		assert.NilError(t, err)
+
+		dirPath := findMkdir(t, ops)
+		assert.Equal(t, dirPath, "/SPECS/myapp")
+
+		filePath, _ := findSpecMkfile(t, ops)
+		assert.Equal(t, filePath, "/SPECS/myapp/myapp.spec")
+	})
+
+	t.Run("custom_directory", func(t *testing.T) {
+		t.Parallel()
+		spec := baseSpec("myapp")
+
+		state := RPMSpec(spec, llb.Scratch(), "", "custom/dir")
+		ops, err := test.LLBOpsFromState(ctx, state)
+		assert.NilError(t, err)
+
+		dirPath := findMkdir(t, ops)
+		assert.Equal(t, dirPath, "/custom/dir")
+
+		filePath, _ := findSpecMkfile(t, ops)
+		assert.Equal(t, filePath, "/custom/dir/myapp.spec")
+	})
+
+	t.Run("spec_without_subpackages", func(t *testing.T) {
+		t.Parallel()
+		spec := baseSpec("foo")
+
+		state := RPMSpec(spec, llb.Scratch(), "azlinux3", "")
+		ops, err := test.LLBOpsFromState(ctx, state)
+		assert.NilError(t, err)
+
+		_, data := findSpecMkfile(t, ops)
+		assert.Assert(t, !strings.Contains(data, "%package -n"), "spec without subpackages should not contain %%package -n")
+	})
+
+	t.Run("spec_with_subpackage_default_name", func(t *testing.T) {
+		t.Parallel()
+		spec := baseSpec("foo")
+		spec.Targets = map[string]dalec.Target{
+			"azlinux3": {
+				Packages: map[string]dalec.SubPackage{
+					"debug": {
+						Description: "Debug symbols for foo",
+						Artifacts: &dalec.Artifacts{
+							Binaries: map[string]dalec.ArtifactConfig{
+								"foo-debug": {},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		state := RPMSpec(spec, llb.Scratch(), "azlinux3", "")
+		ops, err := test.LLBOpsFromState(ctx, state)
+		assert.NilError(t, err)
+
+		_, data := findSpecMkfile(t, ops)
+
+		assert.Assert(t, cmp.Contains(data, "%package -n foo-debug"))
+		assert.Assert(t, cmp.Contains(data, "%description -n foo-debug"))
+		assert.Assert(t, cmp.Contains(data, "Debug symbols for foo"))
+		assert.Assert(t, cmp.Contains(data, "%files -n foo-debug"))
+		assert.Assert(t, cmp.Contains(data, "%{_bindir}/foo-debug"))
+	})
+
+	t.Run("spec_with_subpackage_custom_name", func(t *testing.T) {
+		t.Parallel()
+		spec := baseSpec("foo")
+		spec.Targets = map[string]dalec.Target{
+			"azlinux3": {
+				Packages: map[string]dalec.SubPackage{
+					"compat": {
+						Name:        "foo-compat-v2",
+						Description: "Backward compatibility shim",
+						Artifacts: &dalec.Artifacts{
+							Binaries: map[string]dalec.ArtifactConfig{
+								"foo-v2": {},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		state := RPMSpec(spec, llb.Scratch(), "azlinux3", "")
+		ops, err := test.LLBOpsFromState(ctx, state)
+		assert.NilError(t, err)
+
+		_, data := findSpecMkfile(t, ops)
+
+		assert.Assert(t, cmp.Contains(data, "%package -n foo-compat-v2"))
+		assert.Assert(t, cmp.Contains(data, "%description -n foo-compat-v2"))
+		assert.Assert(t, cmp.Contains(data, "%files -n foo-compat-v2"))
+		assert.Assert(t, cmp.Contains(data, "%{_bindir}/foo-v2"))
+		// Should NOT contain the default derived name
+		assert.Assert(t, !strings.Contains(data, "%package -n foo-compat\n"), "should use custom name, not default")
+	})
+
+	t.Run("spec_with_subpackage_dependencies", func(t *testing.T) {
+		t.Parallel()
+		spec := baseSpec("foo")
+		spec.Targets = map[string]dalec.Target{
+			"azlinux3": {
+				Packages: map[string]dalec.SubPackage{
+					"devel": {
+						Description: "Development files for foo",
+						Dependencies: &dalec.SubPackageDependencies{
+							Runtime: dalec.PackageDependencyList{
+								"foo": dalec.PackageConstraints{
+									Version: []string{"= %{version}-%{release}"},
+								},
+								"libfoo-headers": {},
+							},
+							Recommends: dalec.PackageDependencyList{
+								"foo-docs": {},
+							},
+						},
+						Provides: dalec.PackageDependencyList{
+							"foo-dev": {},
+						},
+						Conflicts: dalec.PackageDependencyList{
+							"foo-devel-old": {
+								Version: []string{"< 1.0"},
+							},
+						},
+						Replaces: dalec.PackageDependencyList{
+							"foo-devel-legacy": {},
+						},
+					},
+				},
+			},
+		}
+
+		state := RPMSpec(spec, llb.Scratch(), "azlinux3", "")
+		ops, err := test.LLBOpsFromState(ctx, state)
+		assert.NilError(t, err)
+
+		_, data := findSpecMkfile(t, ops)
+
+		assert.Assert(t, cmp.Contains(data, "%package -n foo-devel"))
+		assert.Assert(t, cmp.Contains(data, "Requires: foo == %{version}-%{release}"))
+		assert.Assert(t, cmp.Contains(data, "Requires: libfoo-headers"))
+		assert.Assert(t, cmp.Contains(data, "Recommends: foo-docs"))
+		assert.Assert(t, cmp.Contains(data, "Provides: foo-dev"))
+		assert.Assert(t, cmp.Contains(data, "Conflicts: foo-devel-old < 1.0"))
+		assert.Assert(t, cmp.Contains(data, "Obsoletes: foo-devel-legacy"))
+	})
+
+	t.Run("spec_with_multiple_subpackages_sorted", func(t *testing.T) {
+		t.Parallel()
+		spec := baseSpec("foo")
+		spec.Targets = map[string]dalec.Target{
+			"azlinux3": {
+				Packages: map[string]dalec.SubPackage{
+					"debug": {
+						Description: "Debug package",
+						Artifacts: &dalec.Artifacts{
+							Binaries: map[string]dalec.ArtifactConfig{
+								"foo-debug": {},
+							},
+						},
+					},
+					"contrib": {
+						Description: "Contrib package",
+						Artifacts: &dalec.Artifacts{
+							Binaries: map[string]dalec.ArtifactConfig{
+								"foo-contrib": {},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		state := RPMSpec(spec, llb.Scratch(), "azlinux3", "")
+		ops, err := test.LLBOpsFromState(ctx, state)
+		assert.NilError(t, err)
+
+		_, data := findSpecMkfile(t, ops)
+
+		assert.Assert(t, cmp.Contains(data, "%package -n foo-contrib"))
+		assert.Assert(t, cmp.Contains(data, "%package -n foo-debug"))
+
+		// contrib should come before debug (sorted by key)
+		contribIdx := strings.Index(data, "%package -n foo-contrib")
+		debugIdx := strings.Index(data, "%package -n foo-debug")
+		assert.Assert(t, contribIdx < debugIdx, "contrib should appear before debug (sorted by key)")
+	})
+
+	t.Run("spec_with_subpackage_install_artifacts", func(t *testing.T) {
+		t.Parallel()
+		spec := baseSpec("foo")
+		spec.Artifacts = dalec.Artifacts{
+			Binaries: map[string]dalec.ArtifactConfig{
+				"foo": {},
+			},
+		}
+		spec.Targets = map[string]dalec.Target{
+			"azlinux3": {
+				Packages: map[string]dalec.SubPackage{
+					"debug": {
+						Description: "Debug symbols",
+						Artifacts: &dalec.Artifacts{
+							Binaries: map[string]dalec.ArtifactConfig{
+								"foo-debug": {},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		state := RPMSpec(spec, llb.Scratch(), "azlinux3", "")
+		ops, err := test.LLBOpsFromState(ctx, state)
+		assert.NilError(t, err)
+
+		_, data := findSpecMkfile(t, ops)
+
+		// %install section should include both primary and subpackage artifacts
+		assert.Assert(t, cmp.Contains(data, "cp -r foo %{buildroot}/%{_bindir}/foo"))
+		assert.Assert(t, cmp.Contains(data, "cp -r foo-debug %{buildroot}/%{_bindir}/foo-debug"))
+	})
+
+	t.Run("wrong_target_no_subpackages", func(t *testing.T) {
+		t.Parallel()
+		spec := baseSpec("foo")
+		spec.Targets = map[string]dalec.Target{
+			"azlinux3": {
+				Packages: map[string]dalec.SubPackage{
+					"debug": {
+						Description: "Debug",
+					},
+				},
+			},
+		}
+
+		state := RPMSpec(spec, llb.Scratch(), "jammy", "")
+		ops, err := test.LLBOpsFromState(ctx, state)
+		assert.NilError(t, err)
+
+		_, data := findSpecMkfile(t, ops)
+		assert.Assert(t, !strings.Contains(data, "%package -n"), "wrong target should not produce subpackage sections")
+	})
+
+	t.Run("invalid_spec_returns_error", func(t *testing.T) {
+		t.Parallel()
+		// Spec missing required fields (Name, Version, etc.)
+		spec := &dalec.Spec{}
+
+		state := RPMSpec(spec, llb.Scratch(), "", "")
+		_, err := test.LLBOpsFromState(ctx, state)
+		assert.Assert(t, err != nil, "invalid spec should produce an error state that fails to marshal")
+	})
+}

--- a/packaging/linux/rpm/template.go
+++ b/packaging/linux/rpm/template.go
@@ -51,6 +51,7 @@ BuildArch: noarch
 {{ .PreUn -}}
 {{ .PostUn -}}
 {{ .Files -}}
+{{ .SubPackages -}}
 {{ .Changelog -}}
 `)))
 
@@ -553,15 +554,15 @@ func systemdPreUnScript(unitName string, cfg dalec.SystemdUnitConfig) string {
 	return fmt.Sprintf("%%systemd_preun %s\n", unitName)
 }
 
-func (w *specWrapper) PreUn() fmt.Stringer {
-	b := &strings.Builder{}
-
-	artifacts := w.GetArtifacts(w.Target)
+// preUnScriptBody returns the body (without the "%preun" header) of the %preun
+// scriptlet for the given artifacts. It is shared by the primary package and
+// supplemental packages. Returns "" when no preun actions are needed.
+func preUnScriptBody(artifacts dalec.Artifacts) string {
 	if artifacts.Systemd.IsEmpty() || (len(artifacts.Systemd.EnabledUnits()) == 0) {
-		return b
+		return ""
 	}
 
-	b.WriteString("%preun\n")
+	b := &strings.Builder{}
 	keys := dalec.SortMapKeys(artifacts.Systemd.Units)
 	for _, servicePath := range keys {
 		serviceName := filepath.Base(servicePath)
@@ -570,6 +571,19 @@ func (w *specWrapper) PreUn() fmt.Stringer {
 			systemdPreUnScript(serviceName, unitConf),
 		)
 	}
+	return b.String()
+}
+
+func (w *specWrapper) PreUn() fmt.Stringer {
+	b := &strings.Builder{}
+
+	body := preUnScriptBody(w.GetArtifacts(w.Target))
+	if body == "" {
+		return b
+	}
+
+	b.WriteString("%preun\n")
+	b.WriteString(body)
 	return b
 }
 
@@ -607,50 +621,36 @@ fi
 	return s
 }
 
+// postScriptBody returns the body (without the "%post" header) of the %post
+// scriptlet for the given artifacts. It is shared by the primary package and
+// supplemental packages. Returns "" when no post actions are needed.
+func postScriptBody(artifacts dalec.Artifacts) string {
+	b := &strings.Builder{}
+	b.WriteString(systemdPostSection(artifacts))
+	b.WriteString(postUsersScript(artifacts))
+	b.WriteString(postGroupsScript(artifacts))
+	b.WriteString(symlinkOwnershipScript(artifacts))
+	b.WriteString(artifactOwnershipScript(artifacts))
+	b.WriteString(directoryOwnershipScript(artifacts))
+	b.WriteString(artifactCapabilitiesScript(artifacts))
+	return b.String()
+}
+
 func (w *specWrapper) Post() fmt.Stringer {
 	b := &strings.Builder{}
 
-	systemd := w.postSystemd()
-	users := w.postUsers()
-	groups := w.postGroups()
-	symlinkOwnership := w.getSymlinkOwnership()
-	artifactOwnership := w.getArtifactOwnership()
-	directoryOwnership := w.getDirectoryOwnership()
-	artifactCapabilities := w.getArtifactCapabilities()
-
-	if systemd == "" && users == "" && groups == "" && symlinkOwnership == "" && artifactOwnership == "" && directoryOwnership == "" && artifactCapabilities == "" {
+	body := postScriptBody(w.Spec.GetArtifacts(w.Target))
+	if body == "" {
 		return b
 	}
 
 	b.WriteString("%post\n")
-	if systemd != "" {
-		b.WriteString(systemd)
-	}
-	if users != "" {
-		b.WriteString(users)
-	}
-	if groups != "" {
-		b.WriteString(groups)
-	}
-	if symlinkOwnership != "" {
-		b.WriteString(symlinkOwnership)
-	}
-	if artifactOwnership != "" {
-		b.WriteString(artifactOwnership)
-	}
-	if directoryOwnership != "" {
-		b.WriteString(directoryOwnership)
-	}
-	if artifactCapabilities != "" {
-		b.WriteString(artifactCapabilities)
-	}
-
+	b.WriteString(body)
 	b.WriteString("\n")
 	return b
 }
 
-func (w *specWrapper) postUsers() string {
-	artifacts := w.Spec.GetArtifacts(w.Target)
+func postUsersScript(artifacts dalec.Artifacts) string {
 	if len(artifacts.Users) == 0 {
 		return ""
 	}
@@ -662,8 +662,7 @@ func (w *specWrapper) postUsers() string {
 	return b.String()
 }
 
-func (w *specWrapper) postGroups() string {
-	artifacts := w.Spec.GetArtifacts(w.Target)
+func postGroupsScript(artifacts dalec.Artifacts) string {
 	if len(artifacts.Groups) == 0 {
 		return ""
 	}
@@ -675,8 +674,7 @@ func (w *specWrapper) postGroups() string {
 	return b.String()
 }
 
-func (w *specWrapper) getDirectoryOwnership() string {
-	artifacts := w.Spec.GetArtifacts(w.Target)
+func directoryOwnershipScript(artifacts dalec.Artifacts) string {
 	if artifacts.Directories == nil {
 		return ""
 	}
@@ -708,8 +706,7 @@ func (w *specWrapper) getDirectoryOwnership() string {
 	return b.String()
 }
 
-func (w *specWrapper) getArtifactOwnership() string {
-	artifacts := w.Spec.GetArtifacts(w.Target)
+func artifactOwnershipScript(artifacts dalec.Artifacts) string {
 	b := &strings.Builder{}
 
 	setArtifactOwnership := func(root, p string, cfg *dalec.ArtifactConfig) {
@@ -767,8 +764,7 @@ func (w *specWrapper) getArtifactOwnership() string {
 	return b.String()
 }
 
-func (w *specWrapper) getArtifactCapabilities() string {
-	artifacts := w.Spec.GetArtifacts(w.Target)
+func artifactCapabilitiesScript(artifacts dalec.Artifacts) string {
 	b := &strings.Builder{}
 
 	// Only use setcap in postinstall if there's also a chown/chgrp
@@ -816,8 +812,7 @@ func (w *specWrapper) getArtifactCapabilities() string {
 	return b.String()
 }
 
-func (w *specWrapper) getSymlinkOwnership() string {
-	artifacts := w.Spec.GetArtifacts(w.Target)
+func symlinkOwnershipScript(artifacts dalec.Artifacts) string {
 	if len(artifacts.Links) == 0 {
 		return ""
 	}
@@ -843,8 +838,7 @@ func (w *specWrapper) getSymlinkOwnership() string {
 	return b.String()
 }
 
-func (w *specWrapper) postSystemd() string {
-	artifacts := w.Spec.GetArtifacts(w.Target)
+func systemdPostSection(artifacts dalec.Artifacts) string {
 	if artifacts.Systemd.IsEmpty() {
 		return ""
 	}
@@ -869,15 +863,16 @@ func (w *specWrapper) postSystemd() string {
 	return b.String()
 }
 
-func (w *specWrapper) PostUn() fmt.Stringer {
-	b := &strings.Builder{}
-
-	artifacts := w.GetArtifacts(w.Target)
+// postUnScriptBody returns the body (without the "%postun" header) of the
+// %postun scriptlet for the given artifacts. It is shared by the primary
+// package and supplemental packages. Returns "" when no postun actions are
+// needed.
+func postUnScriptBody(artifacts dalec.Artifacts) string {
 	if artifacts.Systemd.IsEmpty() {
-		return b
+		return ""
 	}
 
-	b.WriteString("%postun\n")
+	b := &strings.Builder{}
 	keys := dalec.SortMapKeys(artifacts.Systemd.Units)
 	for _, servicePath := range keys {
 		cfg := artifacts.Systemd.Units[servicePath]
@@ -885,7 +880,19 @@ func (w *specWrapper) PostUn() fmt.Stringer {
 		serviceName := a.ResolveName(servicePath)
 		fmt.Fprintf(b, "%%systemd_postun %s\n", serviceName)
 	}
+	return b.String()
+}
 
+func (w *specWrapper) PostUn() fmt.Stringer {
+	b := &strings.Builder{}
+
+	body := postUnScriptBody(w.GetArtifacts(w.Target))
+	if body == "" {
+		return b
+	}
+
+	b.WriteString("%postun\n")
+	b.WriteString(body)
 	return b
 }
 
@@ -894,7 +901,28 @@ func (w *specWrapper) Install() fmt.Stringer {
 	fmt.Fprintln(b, "%install")
 
 	artifacts := w.Spec.GetArtifacts(w.Target)
+	installArtifacts(b, artifacts, w.Name)
 
+	// Install artifacts for supplemental packages (shared %install section)
+	packages := w.Spec.GetSubPackages(w.Target)
+	if len(packages) > 0 {
+		keys := dalec.SortMapKeys(packages)
+		for _, key := range keys {
+			pkg := packages[key]
+			if pkg.Artifacts != nil {
+				resolvedName := pkg.ResolvedName(w.Spec.Name, key)
+				installArtifacts(b, *pkg.Artifacts, resolvedName)
+			}
+		}
+	}
+
+	b.WriteString("\n")
+	return b
+}
+
+// installArtifacts writes the %install commands for a set of artifacts.
+// pkgName is used for doc/license subdirectories.
+func installArtifacts(b *strings.Builder, artifacts dalec.Artifacts, pkgName string) {
 	copyArtifact := func(root, p string, cfg *dalec.ArtifactConfig) {
 		if cfg == nil {
 			return
@@ -995,14 +1023,14 @@ func (w *specWrapper) Install() fmt.Stringer {
 	docKeys := dalec.SortMapKeys(artifacts.Docs)
 	for _, d := range docKeys {
 		cfg := artifacts.Docs[d]
-		root := filepath.Join(`%{buildroot}/%{_docdir}`, w.Name)
+		root := filepath.Join(`%{buildroot}/%{_docdir}`, pkgName)
 		copyArtifact(root, d, &cfg)
 	}
 
 	licenseKeys := dalec.SortMapKeys(artifacts.Licenses)
 	for _, l := range licenseKeys {
 		cfg := artifacts.Licenses[l]
-		root := filepath.Join(`%{buildroot}/%{_licensedir}`, w.Name)
+		root := filepath.Join(`%{buildroot}/%{_licensedir}`, pkgName)
 		copyArtifact(root, l, &cfg)
 	}
 
@@ -1023,16 +1051,20 @@ func (w *specWrapper) Install() fmt.Stringer {
 		cfg := artifacts.Headers[h]
 		copyArtifact(`%{buildroot}/%{_includedir}`, h, &cfg)
 	}
-	b.WriteString("\n")
-	return b
 }
 
 func (w *specWrapper) Files() fmt.Stringer {
 	b := &strings.Builder{}
 	fmt.Fprintf(b, "%%files\n")
+	writeFilesBody(b, w.GetArtifacts(w.Target), w.Name)
+	b.WriteString("\n")
+	return b
+}
 
-	artifacts := w.GetArtifacts(w.Target)
-
+// writeFilesBody writes the %files entries (without the "%files" header) for
+// the given artifacts. pkgName is used for doc/license subdirectories. It is
+// shared by the primary package and supplemental packages.
+func writeFilesBody(b *strings.Builder, artifacts dalec.Artifacts, pkgName string) {
 	if len(artifacts.Binaries) > 0 {
 		binKeys := dalec.SortMapKeys(artifacts.Binaries)
 		for _, p := range binKeys {
@@ -1147,7 +1179,7 @@ func (w *specWrapper) Files() fmt.Stringer {
 	docKeys := dalec.SortMapKeys(artifacts.Docs)
 	for _, d := range docKeys {
 		cfg := artifacts.Docs[d]
-		path := filepath.Join(`%{_docdir}`, w.Name, cfg.SubPath, cfg.ResolveName(d))
+		path := filepath.Join(`%{_docdir}`, pkgName, cfg.SubPath, cfg.ResolveName(d))
 		fullDirective := strings.Join([]string{`%doc`, path}, " ")
 		fmt.Fprintln(b, fullDirective)
 	}
@@ -1155,7 +1187,7 @@ func (w *specWrapper) Files() fmt.Stringer {
 	licenseKeys := dalec.SortMapKeys(artifacts.Licenses)
 	for _, l := range licenseKeys {
 		cfg := artifacts.Licenses[l]
-		path := filepath.Join(`%{_licensedir}`, w.Name, cfg.SubPath, cfg.ResolveName(l))
+		path := filepath.Join(`%{_licensedir}`, pkgName, cfg.SubPath, cfg.ResolveName(l))
 		fullDirective := strings.Join([]string{`%license`, path}, " ")
 		fmt.Fprintln(b, fullDirective)
 	}
@@ -1197,8 +1229,6 @@ func (w *specWrapper) Files() fmt.Stringer {
 			fmt.Fprintln(b, path)
 		}
 	}
-	b.WriteString("\n")
-	return b
 }
 
 func (w *specWrapper) DisableStrip() string {
@@ -1215,6 +1245,172 @@ func (w *specWrapper) DisableAutoReq() string {
 		return "AutoReq: no"
 	}
 	return ""
+}
+
+// subPkgWrapper holds the resolved metadata for a single supplemental package,
+// used when generating RPM subpackage sections.
+type subPkgWrapper struct {
+	// ResolvedName is the full package name (e.g. "foo-debug" or a custom name).
+	ResolvedName string
+	// Pkg is the supplemental package definition.
+	Pkg dalec.SubPackage
+	// ParentName is the primary package name from the spec.
+	ParentName string
+}
+
+// subPkgDirective returns the RPM directive suffix for this subpackage.
+// We always use "-n <resolved_name>" so that both default-named and
+// custom-named subpackages work uniformly.
+func (s *subPkgWrapper) directive() string {
+	return "-n " + s.ResolvedName
+}
+
+// SubPackages generates all RPM subpackage sections: %package, %description,
+// dependency declarations, %files, and scriptlets (%post, %preun, %postun)
+// for each supplemental package defined in the target.
+func (w *specWrapper) SubPackages() (fmt.Stringer, error) {
+	b := &strings.Builder{}
+
+	packages := w.Spec.GetSubPackages(w.Target)
+	if len(packages) == 0 {
+		return b, nil
+	}
+
+	keys := dalec.SortMapKeys(packages)
+	for _, key := range keys {
+		pkg := packages[key]
+		sw := &subPkgWrapper{
+			ResolvedName: pkg.ResolvedName(w.Spec.Name, key),
+			Pkg:          pkg,
+			ParentName:   w.Spec.Name,
+		}
+
+		sw.writePackageHeader(b)
+		sw.writeDescription(b)
+		sw.writePost(b)
+		sw.writePreUn(b)
+		sw.writePostUn(b)
+		sw.writeFiles(b)
+	}
+
+	return b, nil
+}
+
+// writePackageHeader writes the %package section with Summary and dependency fields.
+func (s *subPkgWrapper) writePackageHeader(b *strings.Builder) {
+	fmt.Fprintf(b, "%%package %s\n", s.directive())
+	fmt.Fprintf(b, "Summary: %s\n", s.Pkg.Description)
+
+	// Install-time requirements for the subpackage's own scriptlets. These do
+	// not come from the spec's declared dependencies; they are derived from the
+	// artifacts the subpackage ships (systemd units, users/groups, ownership).
+	if s.Pkg.Artifacts != nil {
+		b.WriteString(getSystemdRequires(s.Pkg.Artifacts.Systemd))
+		b.WriteString(getUserPostRequires(s.Pkg.Artifacts.Users, s.Pkg.Artifacts.Groups))
+		b.WriteString(getOwnershipPostRequires(*s.Pkg.Artifacts))
+	}
+
+	// Runtime dependencies
+	if deps := s.Pkg.Dependencies.GetRuntime(); len(deps) > 0 {
+		keys := dalec.SortMapKeys(deps)
+		for _, name := range keys {
+			writeDep(b, "Requires", name, deps[name])
+		}
+	}
+
+	// Recommends
+	if deps := s.Pkg.Dependencies.GetRecommends(); len(deps) > 0 {
+		keys := dalec.SortMapKeys(deps)
+		for _, name := range keys {
+			writeDep(b, "Recommends", name, deps[name])
+		}
+	}
+
+	// Provides
+	if len(s.Pkg.Provides) > 0 {
+		keys := dalec.SortMapKeys(s.Pkg.Provides)
+		for _, name := range keys {
+			writeDep(b, "Provides", name, s.Pkg.Provides[name])
+		}
+	}
+
+	// Conflicts
+	if len(s.Pkg.Conflicts) > 0 {
+		keys := dalec.SortMapKeys(s.Pkg.Conflicts)
+		for _, name := range keys {
+			writeDep(b, "Conflicts", name, s.Pkg.Conflicts[name])
+		}
+	}
+
+	// Replaces -> Obsoletes
+	if len(s.Pkg.Replaces) > 0 {
+		keys := dalec.SortMapKeys(s.Pkg.Replaces)
+		for _, name := range keys {
+			writeDep(b, "Obsoletes", name, s.Pkg.Replaces[name])
+		}
+	}
+
+	b.WriteString("\n")
+}
+
+// writeDescription writes the %description section for the subpackage.
+func (s *subPkgWrapper) writeDescription(b *strings.Builder) {
+	fmt.Fprintf(b, "%%description %s\n", s.directive())
+	fmt.Fprintf(b, "%s\n\n", s.Pkg.Description)
+}
+
+// writePost writes the %post scriptlet for the subpackage if needed. It reuses
+// the same body generation as the primary package.
+func (s *subPkgWrapper) writePost(b *strings.Builder) {
+	if s.Pkg.Artifacts == nil {
+		return
+	}
+	body := postScriptBody(*s.Pkg.Artifacts)
+	if body == "" {
+		return
+	}
+	fmt.Fprintf(b, "%%post %s\n", s.directive())
+	b.WriteString(body)
+	b.WriteString("\n")
+}
+
+// writePreUn writes the %preun scriptlet for the subpackage if needed. It
+// reuses the same body generation as the primary package.
+func (s *subPkgWrapper) writePreUn(b *strings.Builder) {
+	if s.Pkg.Artifacts == nil {
+		return
+	}
+	body := preUnScriptBody(*s.Pkg.Artifacts)
+	if body == "" {
+		return
+	}
+	fmt.Fprintf(b, "%%preun %s\n", s.directive())
+	b.WriteString(body)
+	b.WriteString("\n")
+}
+
+// writePostUn writes the %postun scriptlet for the subpackage if needed. It
+// reuses the same body generation as the primary package.
+func (s *subPkgWrapper) writePostUn(b *strings.Builder) {
+	if s.Pkg.Artifacts == nil {
+		return
+	}
+	body := postUnScriptBody(*s.Pkg.Artifacts)
+	if body == "" {
+		return
+	}
+	fmt.Fprintf(b, "%%postun %s\n", s.directive())
+	b.WriteString(body)
+	b.WriteString("\n")
+}
+
+func (s *subPkgWrapper) writeFiles(b *strings.Builder) {
+	fmt.Fprintf(b, "%%files %s\n", s.directive())
+
+	if s.Pkg.Artifacts != nil {
+		writeFilesBody(b, *s.Pkg.Artifacts, s.ResolvedName)
+	}
+	b.WriteString("\n")
 }
 
 // WriteSpec generates an rpm spec from the provided [dalec.Spec] and distro target and writes it to the passed in writer

--- a/packaging/linux/rpm/template_test.go
+++ b/packaging/linux/rpm/template_test.go
@@ -1228,3 +1228,482 @@ func TestTemplate_ProvidesUsersAndGroups(t *testing.T) {
 		assert.Assert(t, cmp.Contains(got, "Provides: group(svc)\n"))
 	})
 }
+func TestTemplate_SubPackages(t *testing.T) {
+	t.Run("no supplemental packages", func(t *testing.T) {
+		t.Parallel()
+		w := &specWrapper{Spec: &dalec.Spec{Name: "foo"}}
+		got, err := w.SubPackages()
+		assert.NilError(t, err)
+		assert.Equal(t, got.String(), "")
+	})
+
+	t.Run("single subpackage with default name", func(t *testing.T) {
+		t.Parallel()
+		w := &specWrapper{
+			Spec: &dalec.Spec{
+				Name: "foo",
+				Targets: map[string]dalec.Target{
+					"azlinux3": {
+						Packages: map[string]dalec.SubPackage{
+							"debug": {
+								Description: "Debug symbols for foo",
+								Artifacts: &dalec.Artifacts{
+									Binaries: map[string]dalec.ArtifactConfig{
+										"foo-debug": {},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Target: "azlinux3",
+		}
+
+		got, err := w.SubPackages()
+		assert.NilError(t, err)
+		s := got.String()
+
+		// Should have %package with -n foo-debug (default naming: parent-key)
+		assert.Assert(t, cmp.Contains(s, "%package -n foo-debug"))
+		assert.Assert(t, cmp.Contains(s, "Summary: Debug symbols for foo"))
+		assert.Assert(t, cmp.Contains(s, "%description -n foo-debug"))
+		assert.Assert(t, cmp.Contains(s, "Debug symbols for foo"))
+		assert.Assert(t, cmp.Contains(s, "%files -n foo-debug"))
+		assert.Assert(t, cmp.Contains(s, "%{_bindir}/foo-debug"))
+	})
+
+	t.Run("subpackage with custom name", func(t *testing.T) {
+		t.Parallel()
+		w := &specWrapper{
+			Spec: &dalec.Spec{
+				Name: "foo",
+				Targets: map[string]dalec.Target{
+					"azlinux3": {
+						Packages: map[string]dalec.SubPackage{
+							"compat": {
+								Name:        "foo-compat-v2",
+								Description: "Backward compatibility shim",
+								Artifacts: &dalec.Artifacts{
+									Binaries: map[string]dalec.ArtifactConfig{
+										"foo-v2": {},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Target: "azlinux3",
+		}
+
+		got, err := w.SubPackages()
+		assert.NilError(t, err)
+		s := got.String()
+
+		// Should use custom name
+		assert.Assert(t, cmp.Contains(s, "%package -n foo-compat-v2"))
+		assert.Assert(t, cmp.Contains(s, "Summary: Backward compatibility shim"))
+		assert.Assert(t, cmp.Contains(s, "%description -n foo-compat-v2"))
+		assert.Assert(t, cmp.Contains(s, "%files -n foo-compat-v2"))
+		assert.Assert(t, cmp.Contains(s, "%{_bindir}/foo-v2"))
+	})
+
+	t.Run("subpackage with dependencies", func(t *testing.T) {
+		t.Parallel()
+		w := &specWrapper{
+			Spec: &dalec.Spec{
+				Name: "foo",
+				Targets: map[string]dalec.Target{
+					"azlinux3": {
+						Packages: map[string]dalec.SubPackage{
+							"devel": {
+								Description: "Development files for foo",
+								Dependencies: &dalec.SubPackageDependencies{
+									Runtime: dalec.PackageDependencyList{
+										"foo": dalec.PackageConstraints{
+											Version: []string{"= %{version}-%{release}"},
+										},
+										"libfoo-headers": {},
+									},
+									Recommends: dalec.PackageDependencyList{
+										"foo-docs": {},
+									},
+								},
+								Provides: dalec.PackageDependencyList{
+									"foo-dev": {},
+								},
+								Conflicts: dalec.PackageDependencyList{
+									"foo-devel-old": {
+										Version: []string{"< 1.0"},
+									},
+								},
+								Replaces: dalec.PackageDependencyList{
+									"foo-devel-legacy": {},
+								},
+							},
+						},
+					},
+				},
+			},
+			Target: "azlinux3",
+		}
+
+		got, err := w.SubPackages()
+		assert.NilError(t, err)
+		s := got.String()
+
+		// Dependencies
+		assert.Assert(t, cmp.Contains(s, "Requires: foo == %{version}-%{release}"))
+		assert.Assert(t, cmp.Contains(s, "Requires: libfoo-headers"))
+		assert.Assert(t, cmp.Contains(s, "Recommends: foo-docs"))
+		assert.Assert(t, cmp.Contains(s, "Provides: foo-dev"))
+		assert.Assert(t, cmp.Contains(s, "Conflicts: foo-devel-old < 1.0"))
+		assert.Assert(t, cmp.Contains(s, "Obsoletes: foo-devel-legacy"))
+	})
+
+	t.Run("multiple subpackages sorted", func(t *testing.T) {
+		t.Parallel()
+		w := &specWrapper{
+			Spec: &dalec.Spec{
+				Name: "foo",
+				Targets: map[string]dalec.Target{
+					"azlinux3": {
+						Packages: map[string]dalec.SubPackage{
+							"debug": {
+								Description: "Debug package",
+								Artifacts: &dalec.Artifacts{
+									Binaries: map[string]dalec.ArtifactConfig{
+										"foo-debug": {},
+									},
+								},
+							},
+							"contrib": {
+								Description: "Contrib package",
+								Artifacts: &dalec.Artifacts{
+									Binaries: map[string]dalec.ArtifactConfig{
+										"foo-contrib": {},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Target: "azlinux3",
+		}
+
+		got, err := w.SubPackages()
+		assert.NilError(t, err)
+		s := got.String()
+
+		// Both subpackages should be present
+		assert.Assert(t, cmp.Contains(s, "%package -n foo-contrib"))
+		assert.Assert(t, cmp.Contains(s, "%package -n foo-debug"))
+
+		// contrib should come before debug (sorted by key)
+		contribIdx := strings.Index(s, "%package -n foo-contrib")
+		debugIdx := strings.Index(s, "%package -n foo-debug")
+		assert.Assert(t, contribIdx < debugIdx, "contrib should appear before debug (sorted)")
+	})
+
+	t.Run("subpackage with nil artifacts", func(t *testing.T) {
+		t.Parallel()
+		w := &specWrapper{
+			Spec: &dalec.Spec{
+				Name: "foo",
+				Targets: map[string]dalec.Target{
+					"azlinux3": {
+						Packages: map[string]dalec.SubPackage{
+							"meta": {
+								Description: "Meta package with no artifacts",
+								Dependencies: &dalec.SubPackageDependencies{
+									Runtime: dalec.PackageDependencyList{
+										"foo":       {},
+										"foo-debug": {},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Target: "azlinux3",
+		}
+
+		got, err := w.SubPackages()
+		assert.NilError(t, err)
+		s := got.String()
+
+		assert.Assert(t, cmp.Contains(s, "%package -n foo-meta"))
+		assert.Assert(t, cmp.Contains(s, "%files -n foo-meta"))
+		// Should have requires but empty files section
+		assert.Assert(t, cmp.Contains(s, "Requires: foo\n"))
+		assert.Assert(t, cmp.Contains(s, "Requires: foo-debug\n"))
+	})
+
+	t.Run("subpackage with systemd units", func(t *testing.T) {
+		t.Parallel()
+		w := &specWrapper{
+			Spec: &dalec.Spec{
+				Name: "foo",
+				Targets: map[string]dalec.Target{
+					"azlinux3": {
+						Packages: map[string]dalec.SubPackage{
+							"service": {
+								Description: "Service package",
+								Artifacts: &dalec.Artifacts{
+									Systemd: &dalec.SystemdConfiguration{
+										Units: map[string]dalec.SystemdUnitConfig{
+											"foo-svc.service": {
+												Enable: true,
+												Start:  true,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Target: "azlinux3",
+		}
+
+		got, err := w.SubPackages()
+		assert.NilError(t, err)
+		s := got.String()
+
+		// Should have service in %files
+		assert.Assert(t, cmp.Contains(s, "%{_unitdir}/foo-svc.service"))
+		// Should have %post for enabling
+		assert.Assert(t, cmp.Contains(s, "%post -n foo-service"))
+		assert.Assert(t, cmp.Contains(s, "systemctl enable foo-svc.service || :"))
+		assert.Assert(t, cmp.Contains(s, "systemctl start foo-svc.service || :"))
+		// Should have %preun for disabling
+		assert.Assert(t, cmp.Contains(s, "%preun -n foo-service"))
+		assert.Assert(t, cmp.Contains(s, "%systemd_preun foo-svc.service"))
+		// Should have %postun
+		assert.Assert(t, cmp.Contains(s, "%postun -n foo-service"))
+		assert.Assert(t, cmp.Contains(s, "%systemd_postun foo-svc.service"))
+		// Should declare install-time scriptlet requirements so the subpackage
+		// pulls in systemd independently of the primary package.
+		assert.Assert(t, cmp.Contains(s, "Requires(post): systemd\n"))
+		assert.Assert(t, cmp.Contains(s, "Requires(preun): systemd\n"))
+		assert.Assert(t, cmp.Contains(s, "Requires(postun): systemd\n"))
+	})
+
+	t.Run("subpackage with users requires adduser at install time", func(t *testing.T) {
+		t.Parallel()
+		w := &specWrapper{
+			Spec: &dalec.Spec{
+				Name: "foo",
+				Targets: map[string]dalec.Target{
+					"azlinux3": {
+						Packages: map[string]dalec.SubPackage{
+							"service": {
+								Description: "Service package",
+								Artifacts: &dalec.Artifacts{
+									Users:  []dalec.AddUserConfig{{Name: "foouser"}},
+									Groups: []dalec.AddGroupConfig{{Name: "foogroup"}},
+								},
+							},
+						},
+					},
+				},
+			},
+			Target: "azlinux3",
+		}
+
+		got, err := w.SubPackages()
+		assert.NilError(t, err)
+		s := got.String()
+
+		assert.Assert(t, cmp.Contains(s, "Requires(post): /usr/sbin/adduser, /usr/bin/getent\n"))
+		assert.Assert(t, cmp.Contains(s, "Requires(post): /usr/sbin/groupadd, /usr/bin/getent\n"))
+	})
+
+	t.Run("subpackage docs and licenses use resolved name", func(t *testing.T) {
+		t.Parallel()
+		w := &specWrapper{
+			Spec: &dalec.Spec{
+				Name: "foo",
+				Targets: map[string]dalec.Target{
+					"azlinux3": {
+						Packages: map[string]dalec.SubPackage{
+							"devel": {
+								Description: "Development files",
+								Artifacts: &dalec.Artifacts{
+									Docs: map[string]dalec.ArtifactConfig{
+										"API.md": {},
+									},
+									Licenses: map[string]dalec.ArtifactConfig{
+										"LICENSE": {},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Target: "azlinux3",
+		}
+
+		got, err := w.SubPackages()
+		assert.NilError(t, err)
+		s := got.String()
+
+		// Docs and licenses should use the subpackage's resolved name
+		assert.Assert(t, cmp.Contains(s, "%doc %{_docdir}/foo-devel/API.md"))
+		assert.Assert(t, cmp.Contains(s, "%license %{_licensedir}/foo-devel/LICENSE"))
+	})
+
+	t.Run("wrong target returns no subpackages", func(t *testing.T) {
+		t.Parallel()
+		w := &specWrapper{
+			Spec: &dalec.Spec{
+				Name: "foo",
+				Targets: map[string]dalec.Target{
+					"azlinux3": {
+						Packages: map[string]dalec.SubPackage{
+							"debug": {
+								Description: "Debug",
+							},
+						},
+					},
+				},
+			},
+			Target: "jammy",
+		}
+
+		got, err := w.SubPackages()
+		assert.NilError(t, err)
+		assert.Equal(t, got.String(), "")
+	})
+}
+
+func TestTemplate_SubPackageInstall(t *testing.T) {
+	t.Run("install includes subpackage artifacts", func(t *testing.T) {
+		t.Parallel()
+		w := &specWrapper{
+			Spec: &dalec.Spec{
+				Name: "foo",
+				Artifacts: dalec.Artifacts{
+					Binaries: map[string]dalec.ArtifactConfig{
+						"foo": {},
+					},
+				},
+				Targets: map[string]dalec.Target{
+					"azlinux3": {
+						Packages: map[string]dalec.SubPackage{
+							"debug": {
+								Description: "Debug symbols",
+								Artifacts: &dalec.Artifacts{
+									Binaries: map[string]dalec.ArtifactConfig{
+										"foo-debug": {},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Target: "azlinux3",
+		}
+
+		got := w.Install().String()
+
+		// Primary package artifact
+		assert.Assert(t, cmp.Contains(got, "cp -r foo %{buildroot}/%{_bindir}/foo"))
+		// Subpackage artifact
+		assert.Assert(t, cmp.Contains(got, "cp -r foo-debug %{buildroot}/%{_bindir}/foo-debug"))
+	})
+
+	t.Run("install subpackage docs use resolved name", func(t *testing.T) {
+		t.Parallel()
+		w := &specWrapper{
+			Spec: &dalec.Spec{
+				Name: "foo",
+				Targets: map[string]dalec.Target{
+					"azlinux3": {
+						Packages: map[string]dalec.SubPackage{
+							"devel": {
+								Description: "Dev files",
+								Artifacts: &dalec.Artifacts{
+									Docs: map[string]dalec.ArtifactConfig{
+										"API.md": {},
+									},
+									Licenses: map[string]dalec.ArtifactConfig{
+										"LICENSE": {},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Target: "azlinux3",
+		}
+
+		got := w.Install().String()
+
+		// Docs and licenses should be installed under the subpackage's resolved name
+		assert.Assert(t, cmp.Contains(got, "%{buildroot}/%{_docdir}/foo-devel"))
+		assert.Assert(t, cmp.Contains(got, "%{buildroot}/%{_licensedir}/foo-devel"))
+	})
+}
+
+func TestTemplate_SubPackageFullSpec(t *testing.T) {
+	t.Parallel()
+
+	spec := &dalec.Spec{
+		Name:        "myapp",
+		Version:     "1.0.0",
+		Revision:    "1",
+		Description: "My application",
+		License:     "MIT",
+		Targets: map[string]dalec.Target{
+			"azlinux3": {
+				Packages: map[string]dalec.SubPackage{
+					"devel": {
+						Description: "Development headers for myapp",
+						Artifacts: &dalec.Artifacts{
+							Headers: map[string]dalec.ArtifactConfig{
+								"myapp.h": {},
+							},
+						},
+						Dependencies: &dalec.SubPackageDependencies{
+							Runtime: dalec.PackageDependencyList{
+								"myapp": {
+									Version: []string{"= %{version}-%{release}"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	w := &strings.Builder{}
+	err := WriteSpec(spec, "azlinux3", w)
+	assert.NilError(t, err)
+
+	s := w.String()
+
+	// Primary package should be present
+	assert.Assert(t, cmp.Contains(s, "Name: myapp"))
+	assert.Assert(t, cmp.Contains(s, "Summary: My application"))
+
+	// Subpackage should be present
+	assert.Assert(t, cmp.Contains(s, "%package -n myapp-devel"))
+	assert.Assert(t, cmp.Contains(s, "Summary: Development headers for myapp"))
+	assert.Assert(t, cmp.Contains(s, "Requires: myapp == %{version}-%{release}"))
+	assert.Assert(t, cmp.Contains(s, "%description -n myapp-devel"))
+	assert.Assert(t, cmp.Contains(s, "Development headers for myapp"))
+	assert.Assert(t, cmp.Contains(s, "%files -n myapp-devel"))
+	assert.Assert(t, cmp.Contains(s, "%{_includedir}/myapp.h"))
+
+	// Install should include subpackage headers
+	assert.Assert(t, cmp.Contains(s, "cp -r myapp.h %{buildroot}/%{_includedir}/myapp.h"))
+}

--- a/subpackage.go
+++ b/subpackage.go
@@ -1,0 +1,243 @@
+package dalec
+
+import (
+	goerrors "errors"
+	"fmt"
+
+	"github.com/moby/buildkit/frontend/dockerfile/shell"
+	"github.com/pkg/errors"
+)
+
+// SubPackageDependencies contains only the dependency fields valid for
+// supplemental packages. Build dependencies are shared with the primary
+// package and cannot be overridden.
+type SubPackageDependencies struct {
+	// Runtime is the list of packages required to install/run the supplemental package.
+	Runtime PackageDependencyList `yaml:"runtime,omitempty" json:"runtime,omitempty"`
+	// Recommends is the list of packages recommended to install with the supplemental package.
+	// Note: Not all package managers support this (e.g. rpm)
+	Recommends PackageDependencyList `yaml:"recommends,omitempty" json:"recommends,omitempty"`
+}
+
+func (d *SubPackageDependencies) GetRuntime() PackageDependencyList {
+	if d == nil {
+		return nil
+	}
+	return d.Runtime
+}
+
+func (d *SubPackageDependencies) GetRecommends() PackageDependencyList {
+	if d == nil {
+		return nil
+	}
+	return d.Recommends
+}
+
+func (d *SubPackageDependencies) processBuildArgs(lex *shell.Lex, args map[string]string, allowArg func(string) bool) error {
+	if d == nil {
+		return nil
+	}
+
+	var errs []error
+	for k, v := range d.Runtime {
+		for i, ver := range v.Version {
+			updated, err := expandArgs(lex, ver, args, allowArg)
+			if err != nil {
+				errs = append(errs, errors.Wrapf(err, "runtime version %s", ver))
+				continue
+			}
+			v.Version[i] = updated
+		}
+		d.Runtime[k] = v
+	}
+
+	for k, v := range d.Recommends {
+		for i, ver := range v.Version {
+			updated, err := expandArgs(lex, ver, args, allowArg)
+			if err != nil {
+				errs = append(errs, errors.Wrapf(err, "recommends version %s", ver))
+				continue
+			}
+			v.Version[i] = updated
+		}
+		d.Recommends[k] = v
+	}
+
+	return goerrors.Join(errs...)
+}
+
+// SubPackage defines a supplemental package produced from the same build
+// output as the primary package. Each supplemental package has its own
+// artifact selection, runtime dependencies, and package metadata.
+//
+// Supplemental packages share the primary package's build steps, sources,
+// version, revision, license, vendor, and website. They cannot override
+// these fields.
+type SubPackage struct {
+	// Name overrides the default package name.
+	// By default, the package name is "<parent>-<key>" where <key> is the map
+	// key under which this SubPackage is defined. Set this to use a fully custom
+	// package name instead.
+	Name string `yaml:"name,omitempty" json:"name,omitempty"`
+
+	// Description is the package description. This is required — both RPM and
+	// Debian require a description/summary for every subpackage.
+	Description string `yaml:"description" json:"description" jsonschema:"required"`
+
+	// Artifacts specifies which build outputs go into this supplemental package.
+	// This is self-contained — no artifacts are inherited from the primary package.
+	Artifacts *Artifacts `yaml:"artifacts,omitempty" json:"artifacts,omitempty"`
+
+	// Dependencies specifies runtime dependencies for this supplemental package.
+	// Only runtime and recommends dependencies are allowed; build dependencies
+	// are shared with the primary package.
+	Dependencies *SubPackageDependencies `yaml:"dependencies,omitempty" json:"dependencies,omitempty"`
+
+	// Conflicts is the list of packages that conflict with this supplemental package.
+	Conflicts PackageDependencyList `yaml:"conflicts,omitempty" json:"conflicts,omitempty"`
+
+	// Provides is the list of things this supplemental package provides.
+	Provides PackageDependencyList `yaml:"provides,omitempty" json:"provides,omitempty"`
+
+	// Replaces is the list of packages that this supplemental package replaces/obsoletes.
+	Replaces PackageDependencyList `yaml:"replaces,omitempty" json:"replaces,omitempty"`
+}
+
+// ResolvedName returns the package name that this SubPackage will produce.
+// If [SubPackage.Name] is set, it is returned as-is.
+// Otherwise, the name is "<parentName>-<mapKey>".
+func (s *SubPackage) ResolvedName(parentName, mapKey string) string {
+	if s.Name != "" {
+		return s.Name
+	}
+	return parentName + "-" + mapKey
+}
+
+func (s *SubPackage) validate() error {
+	var errs []error
+
+	if s.Description == "" {
+		errs = append(errs, fmt.Errorf("description is required"))
+	}
+
+	if s.Artifacts != nil {
+		if err := s.Artifacts.validate(); err != nil {
+			errs = append(errs, errors.Wrap(err, "artifacts"))
+		}
+	}
+
+	return goerrors.Join(errs...)
+}
+
+func (s *SubPackage) processBuildArgs(lex *shell.Lex, args map[string]string, allowArg func(string) bool) error {
+	var errs []error
+
+	if s.Name != "" {
+		updated, err := expandArgs(lex, s.Name, args, allowArg)
+		if err != nil {
+			errs = append(errs, errors.Wrap(err, "name"))
+		} else {
+			s.Name = updated
+		}
+	}
+
+	if s.Description != "" {
+		updated, err := expandArgs(lex, s.Description, args, allowArg)
+		if err != nil {
+			errs = append(errs, errors.Wrap(err, "description"))
+		} else {
+			s.Description = updated
+		}
+	}
+
+	if err := s.Dependencies.processBuildArgs(lex, args, allowArg); err != nil {
+		errs = append(errs, errors.Wrap(err, "dependencies"))
+	}
+
+	for k, v := range s.Conflicts {
+		for i, ver := range v.Version {
+			updated, err := expandArgs(lex, ver, args, allowArg)
+			if err != nil {
+				errs = append(errs, errors.Wrapf(err, "conflicts %s version %d", k, i))
+				continue
+			}
+			s.Conflicts[k].Version[i] = updated
+		}
+	}
+
+	for k, v := range s.Provides {
+		for i, ver := range v.Version {
+			updated, err := expandArgs(lex, ver, args, allowArg)
+			if err != nil {
+				errs = append(errs, errors.Wrapf(err, "provides %s version %d", k, i))
+				continue
+			}
+			s.Provides[k].Version[i] = updated
+		}
+	}
+
+	for k, v := range s.Replaces {
+		for i, ver := range v.Version {
+			updated, err := expandArgs(lex, ver, args, allowArg)
+			if err != nil {
+				errs = append(errs, errors.Wrapf(err, "replaces %s version %d", k, i))
+				continue
+			}
+			s.Replaces[k].Version[i] = updated
+		}
+	}
+
+	return goerrors.Join(errs...)
+}
+
+func (s *SubPackage) fillDefaults() {
+}
+
+// validateSubPackageNames checks that no two supplemental packages in the same
+// target resolve to the same name, and that no supplemental package name
+// conflicts with the primary package name.
+func validateSubPackageNames(specName, targetName string, packages map[string]SubPackage) error {
+	if len(packages) == 0 {
+		return nil
+	}
+
+	var errs []error
+	seen := make(map[string]string, len(packages)) // resolved name → map key
+
+	for key, pkg := range packages {
+		resolved := pkg.ResolvedName(specName, key)
+
+		if resolved == specName {
+			errs = append(errs, fmt.Errorf("target %s: package %q resolves to name %q which conflicts with the primary package name", targetName, key, resolved))
+		}
+
+		if prevKey, exists := seen[resolved]; exists {
+			errs = append(errs, fmt.Errorf("target %s: packages %q and %q both resolve to the same name %q", targetName, prevKey, key, resolved))
+		}
+		seen[resolved] = key
+	}
+
+	return goerrors.Join(errs...)
+}
+
+// GetSubPackages returns the supplemental packages defined for the given target.
+// Returns nil if the target does not exist or has no supplemental packages.
+func (s *Spec) GetSubPackages(targetKey string) map[string]SubPackage {
+	t, ok := s.Targets[targetKey]
+	if !ok {
+		return nil
+	}
+	return t.Packages
+}
+
+// GetAllPackageNames returns the resolved names of all packages (primary +
+// supplemental) for the given target. The primary package name is always first.
+func (s *Spec) GetAllPackageNames(targetKey string) []string {
+	names := []string{s.Name}
+	packages := s.GetSubPackages(targetKey)
+	for _, key := range SortMapKeys(packages) {
+		pkg := packages[key]
+		names = append(names, pkg.ResolvedName(s.Name, key))
+	}
+	return names
+}

--- a/subpackage_test.go
+++ b/subpackage_test.go
@@ -1,0 +1,476 @@
+package dalec
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/goccy/go-yaml"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func TestSubPackageResolvedName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		pkg        SubPackage
+		parentName string
+		mapKey     string
+		expected   string
+	}{
+		{
+			name:       "default naming",
+			pkg:        SubPackage{Description: "test"},
+			parentName: "foo",
+			mapKey:     "debug",
+			expected:   "foo-debug",
+		},
+		{
+			name:       "explicit name override",
+			pkg:        SubPackage{Name: "custom-pkg", Description: "test"},
+			parentName: "foo",
+			mapKey:     "debug",
+			expected:   "custom-pkg",
+		},
+		{
+			name:       "empty explicit name uses default",
+			pkg:        SubPackage{Name: "", Description: "test"},
+			parentName: "bar",
+			mapKey:     "contrib",
+			expected:   "bar-contrib",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.pkg.ResolvedName(tt.parentName, tt.mapKey)
+			assert.Check(t, cmp.Equal(got, tt.expected))
+		})
+	}
+}
+
+func TestSubPackageValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		pkg       SubPackage
+		expectErr bool
+		errSubstr string
+	}{
+		{
+			name: "valid subpackage",
+			pkg: SubPackage{
+				Description: "A debug package",
+				Artifacts: &Artifacts{
+					Binaries: map[string]ArtifactConfig{
+						"dbg/foo": {SubPath: "foo.dbg"},
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name:      "missing description",
+			pkg:       SubPackage{},
+			expectErr: true,
+			errSubstr: "description is required",
+		},
+		{
+			name: "valid with dependencies",
+			pkg: SubPackage{
+				Description: "Contrib package",
+				Dependencies: &SubPackageDependencies{
+					Runtime: PackageDependencyList{
+						"openssl-libs": {},
+					},
+				},
+				Conflicts: PackageDependencyList{
+					"foo": {},
+				},
+				Provides: PackageDependencyList{
+					"foo": {},
+				},
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.pkg.validate()
+			if tt.expectErr {
+				assert.Check(t, err != nil, "expected an error but got nil")
+				if tt.errSubstr != "" {
+					assert.Check(t, cmp.ErrorContains(err, tt.errSubstr))
+				}
+			} else {
+				assert.NilError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateSubPackageNames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		specName   string
+		targetName string
+		packages   map[string]SubPackage
+		expectErr  bool
+		errSubstr  string
+	}{
+		{
+			name:       "nil packages",
+			specName:   "foo",
+			targetName: "azlinux3",
+			packages:   nil,
+			expectErr:  false,
+		},
+		{
+			name:       "empty packages",
+			specName:   "foo",
+			targetName: "azlinux3",
+			packages:   map[string]SubPackage{},
+			expectErr:  false,
+		},
+		{
+			name:       "valid packages with default names",
+			specName:   "foo",
+			targetName: "azlinux3",
+			packages: map[string]SubPackage{
+				"debug":   {Description: "debug pkg"},
+				"contrib": {Description: "contrib pkg"},
+			},
+			expectErr: false,
+		},
+		{
+			name:       "valid packages with explicit name",
+			specName:   "foo",
+			targetName: "azlinux3",
+			packages: map[string]SubPackage{
+				"compat": {Name: "foo-compat-v2", Description: "compat pkg"},
+			},
+			expectErr: false,
+		},
+		{
+			name:       "conflicts with spec name via default naming",
+			specName:   "foo",
+			targetName: "azlinux3",
+			packages: map[string]SubPackage{
+				// This would be weird but: if specName is "foo-debug" and key is "debug"
+				// then resolved = "foo-debug-debug" which doesn't conflict.
+				// But if specName is "foo" and someone sets name: "foo" explicitly:
+				"bad": {Name: "foo", Description: "conflicts with primary"},
+			},
+			expectErr: true,
+			errSubstr: "conflicts with the primary package name",
+		},
+		{
+			name:       "duplicate resolved names from explicit overrides",
+			specName:   "foo",
+			targetName: "azlinux3",
+			packages: map[string]SubPackage{
+				"a": {Name: "same-name", Description: "pkg a"},
+				"b": {Name: "same-name", Description: "pkg b"},
+			},
+			expectErr: true,
+			errSubstr: "both resolve to the same name",
+		},
+		{
+			name:       "duplicate via default and explicit",
+			specName:   "foo",
+			targetName: "azlinux3",
+			packages: map[string]SubPackage{
+				"debug": {Description: "default foo-debug"},
+				"other": {Name: "foo-debug", Description: "also foo-debug"},
+			},
+			expectErr: true,
+			errSubstr: "both resolve to the same name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateSubPackageNames(tt.specName, tt.targetName, tt.packages)
+			if tt.expectErr {
+				assert.Check(t, err != nil, "expected an error but got nil")
+				if tt.errSubstr != "" {
+					assert.Check(t, cmp.ErrorContains(err, tt.errSubstr))
+				}
+			} else {
+				assert.NilError(t, err)
+			}
+		})
+	}
+}
+
+func TestSubPackageYAMLRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original := SubPackage{
+		Name:        "custom-name",
+		Description: "A custom subpackage",
+		Artifacts: &Artifacts{
+			Binaries: map[string]ArtifactConfig{
+				"foo-contrib": {SubPath: "foo"},
+			},
+		},
+		Dependencies: &SubPackageDependencies{
+			Runtime: PackageDependencyList{
+				"openssl-libs": {},
+			},
+			Recommends: PackageDependencyList{
+				"suggested-pkg": {},
+			},
+		},
+		Conflicts: PackageDependencyList{
+			"foo": {},
+		},
+		Provides: PackageDependencyList{
+			"foo": {},
+		},
+		Replaces: PackageDependencyList{
+			"old-foo": {},
+		},
+	}
+
+	data, err := yaml.Marshal(original)
+	assert.NilError(t, err)
+
+	var roundTripped SubPackage
+	err = yaml.Unmarshal(data, &roundTripped)
+	assert.NilError(t, err)
+
+	assert.Check(t, cmp.Equal(roundTripped.Name, original.Name))
+	assert.Check(t, cmp.Equal(roundTripped.Description, original.Description))
+
+	// Check artifacts
+	assert.Check(t, roundTripped.Artifacts != nil)
+	assert.Check(t, cmp.Equal(len(roundTripped.Artifacts.Binaries), 1))
+
+	// Check dependencies
+	assert.Check(t, roundTripped.Dependencies != nil)
+	assert.Check(t, cmp.Equal(len(roundTripped.Dependencies.GetRuntime()), 1))
+	assert.Check(t, cmp.Equal(len(roundTripped.Dependencies.GetRecommends()), 1))
+
+	// Check conflicts/provides/replaces
+	assert.Check(t, cmp.Equal(len(roundTripped.Conflicts), 1))
+	assert.Check(t, cmp.Equal(len(roundTripped.Provides), 1))
+	assert.Check(t, cmp.Equal(len(roundTripped.Replaces), 1))
+}
+
+func TestTargetWithSubPackagesYAML(t *testing.T) {
+	t.Parallel()
+
+	input := `
+targets:
+  azlinux3:
+    packages:
+      debug:
+        description: "Debug symbols for foo"
+        artifacts:
+          binaries:
+            dbg/foo:
+              name: foo.dbg
+        dependencies:
+          runtime:
+            foo: {}
+      contrib:
+        name: foo-contrib-custom
+        description: "Foo with contrib extensions"
+        conflicts:
+          foo: {}
+        provides:
+          foo: {}
+`
+
+	var spec Spec
+	err := yaml.Unmarshal([]byte(input), &spec)
+	assert.NilError(t, err)
+
+	target, ok := spec.Targets["azlinux3"]
+	assert.Check(t, ok, "expected azlinux3 target")
+	assert.Check(t, cmp.Equal(len(target.Packages), 2))
+
+	debugPkg, ok := target.Packages["debug"]
+	assert.Check(t, ok, "expected debug package")
+	assert.Check(t, cmp.Equal(debugPkg.Description, "Debug symbols for foo"))
+	assert.Check(t, cmp.Equal(debugPkg.ResolvedName("foo", "debug"), "foo-debug"))
+
+	contribPkg, ok := target.Packages["contrib"]
+	assert.Check(t, ok, "expected contrib package")
+	assert.Check(t, cmp.Equal(contribPkg.Name, "foo-contrib-custom"))
+	assert.Check(t, cmp.Equal(contribPkg.ResolvedName("foo", "contrib"), "foo-contrib-custom"))
+}
+
+func TestGetSubPackages(t *testing.T) {
+	t.Parallel()
+
+	spec := &Spec{
+		Name: "foo",
+		Targets: map[string]Target{
+			"azlinux3": {
+				Packages: map[string]SubPackage{
+					"debug": {Description: "debug"},
+				},
+			},
+			"jammy": {},
+		},
+	}
+
+	// Target with packages
+	pkgs := spec.GetSubPackages("azlinux3")
+	assert.Check(t, cmp.Equal(len(pkgs), 1))
+	_, ok := pkgs["debug"]
+	assert.Check(t, ok)
+
+	// Target without packages
+	pkgs = spec.GetSubPackages("jammy")
+	assert.Check(t, cmp.Equal(len(pkgs), 0))
+
+	// Non-existent target
+	pkgs = spec.GetSubPackages("nonexistent")
+	assert.Check(t, pkgs == nil)
+}
+
+func TestGetAllPackageNames(t *testing.T) {
+	t.Parallel()
+
+	spec := &Spec{
+		Name: "foo",
+		Targets: map[string]Target{
+			"azlinux3": {
+				Packages: map[string]SubPackage{
+					"debug":   {Description: "debug"},
+					"contrib": {Name: "custom-contrib", Description: "contrib"},
+				},
+			},
+			"jammy": {},
+		},
+	}
+
+	// Target with subpackages
+	names := spec.GetAllPackageNames("azlinux3")
+	assert.Check(t, cmp.Equal(names[0], "foo"), "primary package should be first")
+	assert.Check(t, cmp.Equal(len(names), 3))
+	// The remaining names should include foo-debug and custom-contrib (order may vary for map iteration)
+	remaining := names[1:]
+	slices.Sort(remaining)
+	assert.Check(t, cmp.Equal(remaining[0], "custom-contrib"))
+	assert.Check(t, cmp.Equal(remaining[1], "foo-debug"))
+
+	// Target without subpackages
+	names = spec.GetAllPackageNames("jammy")
+	assert.Check(t, cmp.Equal(len(names), 1))
+	assert.Check(t, cmp.Equal(names[0], "foo"))
+
+	// Non-existent target
+	names = spec.GetAllPackageNames("nonexistent")
+	assert.Check(t, cmp.Equal(len(names), 1))
+	assert.Check(t, cmp.Equal(names[0], "foo"))
+}
+
+func TestSubPackageDependenciesNilSafe(t *testing.T) {
+	t.Parallel()
+
+	var d *SubPackageDependencies
+	assert.Check(t, d.GetRuntime() == nil)
+	assert.Check(t, d.GetRecommends() == nil)
+	assert.NilError(t, d.processBuildArgs(nil, nil, nil))
+}
+
+func TestSpecValidateWithSubPackages(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		spec      Spec
+		expectErr bool
+		errSubstr string
+	}{
+		{
+			name: "valid spec with subpackages",
+			spec: Spec{
+				Name:        "foo",
+				Description: "test",
+				Version:     "1.0.0",
+				Revision:    "1",
+				License:     "MIT",
+				Website:     "https://example.com",
+				Targets: map[string]Target{
+					"azlinux3": {
+						Packages: map[string]SubPackage{
+							"debug":   {Description: "debug symbols"},
+							"contrib": {Description: "contrib features"},
+						},
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "subpackage missing description",
+			spec: Spec{
+				Name:        "foo",
+				Description: "test",
+				Version:     "1.0.0",
+				Revision:    "1",
+				License:     "MIT",
+				Website:     "https://example.com",
+				Targets: map[string]Target{
+					"azlinux3": {
+						Packages: map[string]SubPackage{
+							"debug": {},
+						},
+					},
+				},
+			},
+			expectErr: true,
+			errSubstr: "description is required",
+		},
+		{
+			name: "subpackage name conflicts with primary",
+			spec: Spec{
+				Name:        "foo",
+				Description: "test",
+				Version:     "1.0.0",
+				Revision:    "1",
+				License:     "MIT",
+				Website:     "https://example.com",
+				Targets: map[string]Target{
+					"azlinux3": {
+						Packages: map[string]SubPackage{
+							"bad": {Name: "foo", Description: "conflict"},
+						},
+					},
+				},
+			},
+			expectErr: true,
+			errSubstr: "conflicts with the primary package name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.spec.Validate()
+			if tt.expectErr {
+				assert.Check(t, err != nil, "expected an error but got nil")
+				if tt.errSubstr != "" {
+					assert.Check(t, strings.Contains(err.Error(), tt.errSubstr),
+						"expected error to contain %q, got: %s", tt.errSubstr, err)
+				}
+			} else {
+				assert.NilError(t, err)
+			}
+		})
+	}
+}

--- a/target.go
+++ b/target.go
@@ -51,6 +51,12 @@ type Target struct {
 
 	// Conflicts is the list of packages that this target conflicts with.
 	Conflicts PackageDependencyList `yaml:"conflicts,omitempty" json:"conflicts,omitempty"`
+
+	// Packages defines supplemental packages produced from the same build output
+	// as the primary package. Each entry produces an additional package with its
+	// own artifact selection, runtime dependencies, and metadata.
+	// The map key is used as a suffix for the default package name ("<specName>-<key>").
+	Packages map[string]SubPackage `yaml:"packages,omitempty" json:"packages,omitempty"`
 }
 
 func (t *Target) validate() error {
@@ -71,6 +77,12 @@ func (t *Target) validate() error {
 
 	if err := t.Image.validate(); err != nil {
 		errs = append(errs, errors.Wrap(err, "postinstall"))
+	}
+
+	for key, pkg := range t.Packages {
+		if err := pkg.validate(); err != nil {
+			errs = append(errs, errors.Wrapf(err, "package %s", key))
+		}
 	}
 
 	return goerrors.Join(errs...)
@@ -131,10 +143,22 @@ func (t *Target) processBuildArgs(lex *shell.Lex, args map[string]string, allowA
 		}
 	}
 
+	for key, pkg := range t.Packages {
+		if err := pkg.processBuildArgs(lex, args, allowArg); err != nil {
+			errs = append(errs, errors.Wrapf(err, "package %s", key))
+		}
+		t.Packages[key] = pkg
+	}
+
 	return goerrors.Join(errs...)
 }
 
 func (t *Target) fillDefaults() {
 	t.Dependencies.fillDefaults()
 	t.Image.fillDefaults()
+
+	for key, pkg := range t.Packages {
+		pkg.fillDefaults()
+		t.Packages[key] = pkg
+	}
 }

--- a/targets/windows/handle_container.go
+++ b/targets/windows/handle_container.go
@@ -140,9 +140,38 @@ func handleContainer(ctx context.Context, client gwclient.Client) (*gwclient.Res
 			platform = &defaultPlatform
 		}
 		baseImage := bi.ToState(sOpt, pg, llb.Platform(*platform))
-		out := baseImage.
-			File(llb.Copy(bin, "/", windowsSystemDir), pg).
-			With(copySymlinks(spec.GetImagePost(targetKey), pg))
+
+		// Install every package's binaries (primary + supplemental) into the
+		// image, matching the linux container target which installs all packages
+		// produced for the target.
+		//
+		// The primary package's binaries are at the root of bin, alongside the
+		// supplemental package subdirs. Always copy the root contents (excluding
+		// those subdirs) so the build step is realized in the graph even when the
+		// primary package has no binaries. Otherwise buildkit would prune the
+		// build, and specs that rely on a failing build step would wrongly succeed.
+		pkgs := windowsPackages(spec, targetKey)
+
+		var subPackageDirs []string
+		for _, pkg := range pkgs {
+			if !pkg.Primary {
+				subPackageDirs = append(subPackageDirs, pkg.Name)
+			}
+		}
+
+		out := baseImage.File(
+			llb.Copy(bin, "/", windowsSystemDir, dalec.WithDirContentsOnly(), llb.WithExcludePatterns(subPackageDirs)),
+			pg,
+		)
+
+		// Flatten each supplemental package's binaries into the system directory.
+		for _, pkg := range pkgs {
+			if pkg.Primary || len(pkg.Binaries) == 0 {
+				continue
+			}
+			out = out.File(llb.Copy(bin, "/"+pkg.Name+"/", windowsSystemDir, dalec.WithDirContentsOnly()), pg)
+		}
+		out = out.With(copySymlinks(spec.GetImagePost(targetKey), pg))
 
 		def, err := out.Marshal(ctx)
 		if err != nil {

--- a/targets/windows/handle_zip.go
+++ b/targets/windows/handle_zip.go
@@ -31,12 +31,16 @@ func handleZip(ctx context.Context, client gwclient.Client) (*gwclient.Result, e
 			return nil, nil, err
 		}
 
+		if err := validateZipArtifacts(spec, targetKey); err != nil {
+			return nil, nil, err
+		}
+
 		pg := dalec.ProgressGroup("Build windows container: " + spec.Name)
 		worker := distroConfig.Worker(sOpt, pg)
 
 		bin := buildBinaries(ctx, spec, worker, client, sOpt, targetKey, pg)
 
-		st := getZipLLB(worker, platform, spec, bin, pg)
+		st := getZipLLB(worker, platform, spec, targetKey, bin, pg)
 
 		def, err := st.Marshal(ctx)
 		if err != nil {
@@ -177,8 +181,7 @@ func buildBinaries(ctx context.Context, spec *dalec.Spec, worker llb.State, clie
 
 	patched := dalec.PatchSources(worker, spec, sources, opts...)
 	buildScript := createBuildScript(spec, opts...)
-	artifacts := spec.GetArtifacts(targetKey)
-	script := generateInvocationScript(artifacts.Binaries)
+	script := generateInvocationScript(spec, targetKey)
 
 	builder := worker.With(dalec.SetBuildNetworkMode(spec))
 	st := builder.Run(
@@ -208,32 +211,116 @@ func buildBinaries(ctx context.Context, spec *dalec.Spec, worker llb.State, clie
 	return frontend.MaybeSign(ctx, client, st, spec, targetKey, sOpt)
 }
 
-func getZipLLB(worker llb.State, platform *ocispecs.Platform, spec *dalec.Spec, artifacts llb.State, opts ...llb.ConstraintsOpt) llb.State {
-	fileName := fmt.Sprintf("%s_%s-%s_%s.zip", spec.Name, spec.Version, spec.Revision, platform.Architecture)
-	outName := filepath.Join(outputDir, fileName)
+func getZipLLB(worker llb.State, platform *ocispecs.Platform, spec *dalec.Spec, targetKey string, artifacts llb.State, opts ...llb.ConstraintsOpt) llb.State {
+	const artifactsDir = "/tmp/artifacts"
+
+	// Each package is zipped into a separate
+	// "<name>_<version>-<revision>_<arch>.zip" file. The primary package's
+	// artifacts live at the root of the artifacts dir; supplemental packages
+	// live under their own subdirectory.
+	script := &strings.Builder{}
+	fmt.Fprintln(script, "set -ex")
+	for _, pkg := range windowsPackages(spec, targetKey) {
+		fileName := fmt.Sprintf("%s_%s-%s_%s.zip", pkg.Name, spec.Version, spec.Revision, platform.Architecture)
+		outName := filepath.Join(outputDir, fileName)
+		if pkg.Primary {
+			// Zip only the top-level files so the supplemental package subdirs
+			// are not pulled into the primary archive. This also handles the
+			// package signer, which replaces the artifacts with a flat set of
+			// files at the root.
+			fmt.Fprintf(script, "(cd %q && find . -maxdepth 1 -type f -exec zip %q {} +)\n", artifactsDir, outName)
+			continue
+		}
+		srcDir := path.Join(artifactsDir, pkg.Name)
+		fmt.Fprintf(script, "(cd %q && zip %q *)\n", srcDir, outName)
+	}
+
 	zipped := worker.Run(
-		dalec.ShArgs("zip "+outName+" *"),
-		llb.Dir("/tmp/artifacts"),
-		llb.AddMount("/tmp/artifacts", artifacts),
+		dalec.ShArgs(script.String()),
+		llb.AddMount(artifactsDir, artifacts),
 		dalec.WithConstraints(opts...),
 	).AddMount(outputDir, llb.Scratch())
 	return zipped
 }
 
-func generateInvocationScript(binaries map[string]dalec.ArtifactConfig) *strings.Builder {
+// windowsPackage pairs a resolved package name with the binary artifacts that
+// go into it for a windows target.
+type windowsPackage struct {
+	// Name is the resolved package name (primary package name or the
+	// supplemental package's resolved name).
+	Name string
+	// Binaries are the binary artifacts that belong to this package.
+	Binaries map[string]dalec.ArtifactConfig
+	// Primary is true for the spec's primary package. The primary package's
+	// artifacts are staged at the root of the staging dir (matching the
+	// original single-package layout); supplemental packages are staged under
+	// their own subdirectory.
+	Primary bool
+}
+
+// windowsPackages returns the ordered set of packages produced for a windows
+// target: the primary package first, followed by supplemental packages sorted
+// by their map key. Windows packages only ship binaries.
+func windowsPackages(spec *dalec.Spec, targetKey string) []windowsPackage {
+	pkgs := []windowsPackage{{
+		Name:     spec.Name,
+		Binaries: spec.GetArtifacts(targetKey).Binaries,
+		Primary:  true,
+	}}
+
+	sub := spec.GetSubPackages(targetKey)
+	for _, key := range dalec.SortMapKeys(sub) {
+		p := sub[key]
+		var binaries map[string]dalec.ArtifactConfig
+		if p.Artifacts != nil {
+			binaries = p.Artifacts.Binaries
+		}
+		pkgs = append(pkgs, windowsPackage{
+			Name:     p.ResolvedName(spec.Name, key),
+			Binaries: binaries,
+		})
+	}
+
+	return pkgs
+}
+
+func generateInvocationScript(spec *dalec.Spec, targetKey string) *strings.Builder {
 	script := &strings.Builder{}
 	fmt.Fprintln(script, "#!/usr/bin/env sh")
 	fmt.Fprintln(script, "set -ex")
 	fmt.Fprintf(script, "/tmp/scripts/%s\n", buildScriptName)
-	sorted := dalec.SortMapKeys(binaries)
+
+	// Stage each package's binaries so the zip and container targets can address
+	// them. The primary package is staged at the root of outputDir (the original
+	// single-package layout, which the package signer also flattens to); each
+	// supplemental package is staged under its own "outputDir/<name>" subdir.
+	// Files are copied (not moved) so a build output shared by multiple packages
+	// stays available.
+	for _, pkg := range windowsPackages(spec, targetKey) {
+		destDir := outputDir
+		if !pkg.Primary {
+			destDir = path.Join(outputDir, pkg.Name)
+		}
+		writePackageArtifacts(script, destDir, pkg)
+	}
+
+	return script
+}
+
+// writePackageArtifacts writes the commands that stage a single package's
+// binaries under destDir.
+func writePackageArtifacts(script *strings.Builder, destDir string, pkg windowsPackage) {
+	fmt.Fprintf(script, "mkdir -p '%s'\n", destDir)
+
+	sorted := dalec.SortMapKeys(pkg.Binaries)
 	for _, bin := range sorted {
-		config := binaries[bin]
-		fmt.Fprintf(script, "mv '%s' '%s'\n", bin, outputDir)
+		config := pkg.Binaries[bin]
+		dest := path.Join(destDir, config.ResolveName(bin))
+		fmt.Fprintf(script, "cp -r '%s' '%s'\n", bin, dest)
 		if config.Permissions.Perm() != 0 {
-			fmt.Fprintf(script, "chmod %o '%s/%s'\n", config.Permissions.Perm(), outputDir, bin)
+			fmt.Fprintf(script, "chmod %o '%s'\n", config.Permissions.Perm(), dest)
 		}
 	}
-	return script
 }
 
 func createBuildScript(spec *dalec.Spec, opts ...llb.ConstraintsOpt) llb.State {

--- a/targets/windows/handle_zip_test.go
+++ b/targets/windows/handle_zip_test.go
@@ -1,0 +1,127 @@
+package windows
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/project-dalec/dalec"
+	"gotest.tools/v3/assert"
+)
+
+const testTargetKey = "windowscross"
+
+func subpackageSpec() *dalec.Spec {
+	return &dalec.Spec{
+		Name:    "foo",
+		Version: "1.0.0",
+		Artifacts: dalec.Artifacts{
+			Binaries: map[string]dalec.ArtifactConfig{
+				"bin/foo.exe": {},
+			},
+		},
+		Targets: map[string]dalec.Target{
+			testTargetKey: {
+				Packages: map[string]dalec.SubPackage{
+					"contrib": {
+						Description: "Contrib extras for foo",
+						Artifacts: &dalec.Artifacts{
+							Binaries: map[string]dalec.ArtifactConfig{
+								"bin/foo-contrib.exe": {},
+							},
+						},
+					},
+					"tools": {
+						Name:        "foo-utilities",
+						Description: "Foo utilities",
+						Artifacts: &dalec.Artifacts{
+							Binaries: map[string]dalec.ArtifactConfig{
+								"bin/util.exe": {Name: "foo-util.exe"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestWindowsPackages(t *testing.T) {
+	spec := subpackageSpec()
+	pkgs := windowsPackages(spec, testTargetKey)
+
+	// Primary is always first; supplemental packages follow sorted by map key
+	// ("contrib" before "tools").
+	assert.Equal(t, len(pkgs), 3)
+	assert.Equal(t, pkgs[0].Name, "foo")
+	assert.Equal(t, pkgs[1].Name, "foo-contrib")
+	// "tools" has a name override.
+	assert.Equal(t, pkgs[2].Name, "foo-utilities")
+
+	assert.Equal(t, len(pkgs[0].Binaries), 1)
+	assert.Equal(t, len(pkgs[2].Binaries), 1)
+}
+
+func TestGenerateInvocationScript(t *testing.T) {
+	spec := subpackageSpec()
+	script := generateInvocationScript(spec, testTargetKey).String()
+
+	// The primary package stages at the root of the output dir; supplemental
+	// packages each get their own subdirectory.
+	assert.Assert(t, strings.Contains(script, "mkdir -p '"+outputDir+"'"))
+	assert.Assert(t, strings.Contains(script, "mkdir -p '"+outputDir+"/foo-contrib'"))
+	assert.Assert(t, strings.Contains(script, "mkdir -p '"+outputDir+"/foo-utilities'"))
+
+	// Files are copied (not moved) into the package's staging directory by their
+	// resolved name. The primary package's files land at the output dir root.
+	assert.Assert(t, strings.Contains(script, "cp -r 'bin/foo.exe' '"+outputDir+"/foo.exe'"))
+	assert.Assert(t, strings.Contains(script, "cp -r 'bin/foo-contrib.exe' '"+outputDir+"/foo-contrib/foo-contrib.exe'"))
+	// Name override on the artifact is honored.
+	assert.Assert(t, strings.Contains(script, "cp -r 'bin/util.exe' '"+outputDir+"/foo-utilities/foo-util.exe'"))
+
+	// The build script is still invoked.
+	assert.Assert(t, strings.Contains(script, buildScriptName))
+}
+
+func TestGenerateInvocationScriptPermissions(t *testing.T) {
+	spec := &dalec.Spec{
+		Name: "foo",
+		Artifacts: dalec.Artifacts{
+			Binaries: map[string]dalec.ArtifactConfig{
+				"sub/dir/foo.exe": {Permissions: 0o755},
+			},
+		},
+	}
+
+	script := generateInvocationScript(spec, testTargetKey).String()
+
+	// chmod must target the staged file (by resolved name), not the original
+	// build path. This guards against the previous bug where chmod referenced
+	// the source path under the output dir. The primary package stages at the
+	// output dir root.
+	assert.Assert(t, strings.Contains(script, "cp -r 'sub/dir/foo.exe' '"+outputDir+"/foo.exe'"))
+	assert.Assert(t, strings.Contains(script, "chmod 755 '"+outputDir+"/foo.exe'"))
+}
+
+func TestValidateZipArtifacts(t *testing.T) {
+	t.Run("all packages have artifacts", func(t *testing.T) {
+		spec := subpackageSpec()
+		assert.NilError(t, validateZipArtifacts(spec, testTargetKey))
+	})
+
+	t.Run("empty subpackage", func(t *testing.T) {
+		spec := subpackageSpec()
+		tgt := spec.Targets[testTargetKey]
+		tgt.Packages["empty"] = dalec.SubPackage{Description: "no artifacts"}
+		spec.Targets[testTargetKey] = tgt
+
+		err := validateZipArtifacts(spec, testTargetKey)
+		assert.ErrorContains(t, err, "foo-empty")
+		assert.ErrorContains(t, err, "no artifacts")
+	})
+
+	t.Run("empty primary", func(t *testing.T) {
+		spec := &dalec.Spec{Name: "foo"}
+		err := validateZipArtifacts(spec, testTargetKey)
+		assert.ErrorContains(t, err, "\"foo\"")
+	})
+}

--- a/targets/windows/validation.go
+++ b/targets/windows/validation.go
@@ -1,6 +1,7 @@
 package windows
 
 import (
+	goerrors "errors"
 	"fmt"
 
 	"github.com/project-dalec/dalec"
@@ -13,4 +14,17 @@ func validateRuntimeDeps(s *dalec.Spec, targetKey string) error {
 	}
 
 	return nil
+}
+
+// validateZipArtifacts ensures every package produced for a windowscross/zip
+// target ships at least one artifact. A zip file must contain something, so an
+// empty primary or supplemental package is rejected.
+func validateZipArtifacts(spec *dalec.Spec, targetKey string) error {
+	var errs []error
+	for _, pkg := range windowsPackages(spec, targetKey) {
+		if len(pkg.Binaries) == 0 {
+			errs = append(errs, fmt.Errorf("package %q produces no artifacts; windowscross/zip requires at least one binary per package", pkg.Name))
+		}
+	}
+	return goerrors.Join(errs...)
 }

--- a/test/linux_target_test.go
+++ b/test/linux_target_test.go
@@ -3889,6 +3889,12 @@ func Value() string {
 		ctx := startTestSpan(baseCtx, t)
 		testArtifactCapabilities(ctx, t, testConfig)
 	})
+
+	t.Run("subpackages", func(t *testing.T) {
+		t.Parallel()
+		ctx := startTestSpan(baseCtx, t)
+		testSubpackages(ctx, t, testConfig.Target)
+	})
 }
 
 func testNodeNpmGenerator(ctx context.Context, t *testing.T, targetCfg targetConfig, opts ...srOpt) {

--- a/test/subpackage_test.go
+++ b/test/subpackage_test.go
@@ -1,0 +1,243 @@
+package test
+
+import (
+	"context"
+	"io/fs"
+	"path"
+	"strings"
+	"testing"
+
+	gwclient "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/project-dalec/dalec"
+	"github.com/project-dalec/dalec/frontend/pkg/bkfs"
+)
+
+// subpackageSpec returns a spec that produces a primary package and one
+// subpackage ("contrib"). The primary package installs "primary-bin" to
+// /usr/bin and the subpackage installs "contrib-bin" to /usr/bin.
+func subpackageSpec(targetKey string) *dalec.Spec {
+	return &dalec.Spec{
+		Name:        "test-subpkgs",
+		Version:     "0.0.1",
+		Revision:    "1",
+		Description: "Test subpackages end-to-end",
+		License:     "MIT",
+		Website:     "https://github.com/project-dalec/dalec",
+		Packager:    "test",
+		Sources: map[string]dalec.Source{
+			"primary-bin": {
+				Inline: &dalec.SourceInline{
+					File: &dalec.SourceInlineFile{
+						Contents:    "#!/usr/bin/env bash\necho primary",
+						Permissions: 0o755,
+					},
+				},
+			},
+			"contrib-bin": {
+				Inline: &dalec.SourceInline{
+					File: &dalec.SourceInlineFile{
+						Contents:    "#!/usr/bin/env bash\necho contrib",
+						Permissions: 0o755,
+					},
+				},
+			},
+		},
+		Build: dalec.ArtifactBuild{
+			Steps: []dalec.BuildStep{
+				{Command: "/bin/true"},
+			},
+		},
+		Artifacts: dalec.Artifacts{
+			Binaries: map[string]dalec.ArtifactConfig{
+				"primary-bin": {},
+			},
+		},
+		Targets: map[string]dalec.Target{
+			targetKey: {
+				Packages: map[string]dalec.SubPackage{
+					"contrib": {
+						Description: "Contributed extras for test-subpkgs",
+						Artifacts: &dalec.Artifacts{
+							Binaries: map[string]dalec.ArtifactConfig{
+								"contrib-bin": {},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// testSubpackages tests that supplemental packages (subpackages) are correctly
+// built and installed into the container alongside the primary package.
+func testSubpackages(ctx context.Context, t *testing.T, targetCfg targetConfig) {
+	t.Run("primary and subpackage binaries are installed", func(t *testing.T) {
+		t.Parallel()
+		ctx := startTestSpan(ctx, t)
+
+		spec := subpackageSpec(targetCfg.Key)
+		// Add tests that verify both binaries are present in the container.
+		spec.Tests = []*dalec.TestSpec{
+			{
+				Name: "both binaries installed",
+				Files: map[string]dalec.FileCheckOutput{
+					"/usr/bin/primary-bin": {},
+					"/usr/bin/contrib-bin": {},
+				},
+				Steps: []dalec.TestStep{
+					{
+						Command: "/usr/bin/primary-bin",
+						Stdout:  dalec.CheckOutput{Equals: "primary\n"},
+						Stderr:  dalec.CheckOutput{Empty: true},
+					},
+					{
+						Command: "/usr/bin/contrib-bin",
+						Stdout:  dalec.CheckOutput{Equals: "contrib\n"},
+						Stderr:  dalec.CheckOutput{Empty: true},
+					},
+				},
+			},
+		}
+
+		testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
+			sr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(targetCfg.Container))
+			solveT(ctx, t, gwc, sr)
+		})
+	})
+
+	t.Run("subpackage with custom name", func(t *testing.T) {
+		t.Parallel()
+		ctx := startTestSpan(ctx, t)
+
+		spec := subpackageSpec(targetCfg.Key)
+		// Override the subpackage name.
+		pkg := spec.Targets[targetCfg.Key].Packages["contrib"]
+		pkg.Name = "my-custom-pkg"
+		spec.Targets[targetCfg.Key].Packages["contrib"] = pkg
+
+		// The container target installs all packages regardless of name,
+		// so the binary should still be present.
+		spec.Tests = []*dalec.TestSpec{
+			{
+				Name: "custom-named subpackage binary installed",
+				Files: map[string]dalec.FileCheckOutput{
+					"/usr/bin/contrib-bin": {},
+				},
+			},
+		}
+
+		testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
+			sr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(targetCfg.Container))
+			solveT(ctx, t, gwc, sr)
+		})
+	})
+
+	t.Run("subpackage runtime dependencies are installed", func(t *testing.T) {
+		t.Parallel()
+		ctx := startTestSpan(ctx, t)
+
+		spec := subpackageSpec(targetCfg.Key)
+		pkg := spec.Targets[targetCfg.Key].Packages["contrib"]
+		pkg.Dependencies = &dalec.SubPackageDependencies{
+			Runtime: map[string]dalec.PackageConstraints{
+				"bash": {},
+			},
+		}
+		spec.Targets[targetCfg.Key].Packages["contrib"] = pkg
+
+		spec.Tests = []*dalec.TestSpec{
+			{
+				Name: "bash is available from subpackage dependency",
+				Steps: []dalec.TestStep{
+					{
+						Command: "/bin/bash -c 'echo dep-ok'",
+						Stdout:  dalec.CheckOutput{Contains: []string{"dep-ok"}},
+					},
+				},
+			},
+		}
+
+		testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
+			sr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(targetCfg.Container))
+			solveT(ctx, t, gwc, sr)
+		})
+	})
+
+	t.Run("package target produces subpackage artifacts", func(t *testing.T) {
+		t.Parallel()
+		ctx := startTestSpan(ctx, t)
+
+		spec := subpackageSpec(targetCfg.Key)
+
+		testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
+			sr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(targetCfg.Package))
+			res := solveT(ctx, t, gwc, sr)
+
+			ref, err := res.SingleRef()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			checkSubpackageArtifacts(t, bkfs.FromRef(ctx, ref), spec.Name, "test-subpkgs-contrib")
+		})
+	})
+}
+
+// checkSubpackageArtifacts walks the package-target output filesystem looking
+// for built package artifacts and fails the test unless both the primary
+// package and the subpackage artifacts are present. It handles both RPM
+// (<name>-<version>-<release>.<arch>.rpm) and DEB (<name>_<version>_<arch>.deb)
+// naming conventions, distinguished by the separator that follows the package
+// name. The test also fails if no package artifacts (.rpm or .deb) are found at
+// all.
+func checkSubpackageArtifacts(t *testing.T, fsys fs.FS, primaryName, subpackageName string) {
+	t.Helper()
+
+	var sawPackage, primaryFound, subFound bool
+	err := fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		name := path.Base(p)
+
+		// RPMs separate the name from the version with "-"; DEBs use "_".
+		var sep string
+		switch {
+		case strings.HasSuffix(name, ".rpm"):
+			sep = "-"
+		case strings.HasSuffix(name, ".deb"):
+			sep = "_"
+		default:
+			return nil
+		}
+		sawPackage = true
+
+		// Check the subpackage first: its name is a superstring of the primary
+		// package name, so the primary prefix would otherwise also match it.
+		switch {
+		case strings.HasPrefix(name, subpackageName+sep):
+			subFound = true
+		case strings.HasPrefix(name, primaryName+sep):
+			primaryFound = true
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("error walking package output: %v", err)
+	}
+
+	if !sawPackage {
+		t.Fatal("no package artifacts (.rpm or .deb) found in package output")
+	}
+	if !primaryFound {
+		t.Errorf("primary package artifact (%s) not found in package output", primaryName)
+	}
+	if !subFound {
+		t.Errorf("subpackage artifact (%s) not found in package output", subpackageName)
+	}
+}

--- a/test/target_almalinux_test.go
+++ b/test/target_almalinux_test.go
@@ -64,6 +64,7 @@ func TestAlmalinux8(t *testing.T) {
 	ctx := startTestSpan(baseCtx, t)
 	cfg := testLinuxConfig{
 		Target: targetConfig{
+			Key:       "almalinux8",
 			Package:   "almalinux8/rpm",
 			Container: "almalinux8/container",
 			DepsOnly:  "almalinux8/container/depsonly",

--- a/test/target_rockylinux_test.go
+++ b/test/target_rockylinux_test.go
@@ -64,6 +64,7 @@ func TestRockylinux8(t *testing.T) {
 	ctx := startTestSpan(baseCtx, t)
 	cfg := testLinuxConfig{
 		Target: targetConfig{
+			Key:       "rockylinux8",
 			Package:   "rockylinux8/rpm",
 			Container: "rockylinux8/container",
 			DepsOnly:  "rockylinux8/container/depsonly",

--- a/test/windows_test.go
+++ b/test/windows_test.go
@@ -131,6 +131,12 @@ deb [trusted=yes] copy:` + repoPath + `/ /
 		ctx := startTestSpan(baseCtx, t)
 		testWindowsZipFilename(ctx, t)
 	})
+
+	t.Run("subpackages", func(t *testing.T) {
+		t.Parallel()
+		ctx := startTestSpan(baseCtx, t)
+		testWindowsSubpackages(ctx, t)
+	})
 }
 
 // Windows is only supported on amd64 (ie there is no arm64 windows image currently)
@@ -828,6 +834,80 @@ func testWindowsDefaultPlatform(ctx context.Context, t *testing.T) {
 	testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
 		sr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget("windowscross/zip"))
 		solveT(ctx, t, gwc, sr)
+	})
+}
+
+// testWindowsSubpackages exercises the windowscross/zip subpackage behavior:
+// a single build produces one zip per package (primary + supplemental), and a
+// package that resolves to no artifacts is rejected because an empty zip is
+// meaningless.
+func testWindowsSubpackages(ctx context.Context, t *testing.T) {
+	const targetKey = "windowscross"
+
+	newSpec := func() *dalec.Spec {
+		return fillMetadata("test-win-subpkgs", &dalec.Spec{
+			Build: dalec.ArtifactBuild{
+				Steps: []dalec.BuildStep{
+					{Command: "echo primary > primary.exe; echo contrib > contrib.exe"},
+				},
+			},
+			Artifacts: dalec.Artifacts{
+				Binaries: map[string]dalec.ArtifactConfig{
+					"primary.exe": {},
+				},
+			},
+			Targets: map[string]dalec.Target{
+				targetKey: {
+					Packages: map[string]dalec.SubPackage{
+						"contrib": {
+							Description: "Contributed extras",
+							Artifacts: &dalec.Artifacts{
+								Binaries: map[string]dalec.ArtifactConfig{
+									"contrib.exe": {},
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+	}
+
+	t.Run("one zip per package", func(t *testing.T) {
+		t.Parallel()
+		ctx := startTestSpan(ctx, t)
+		spec := newSpec()
+
+		testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
+			sr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget("windowscross/zip"))
+			res := solveT(ctx, t, gwc, sr)
+			ref, err := res.SingleRef()
+			assert.NilError(t, err)
+
+			for _, name := range []string{spec.Name, spec.Name + "-contrib"} {
+				filename := fmt.Sprintf("/%s_%s-%s_%s.zip", name, spec.Version, spec.Revision, runtime.GOARCH)
+				stat, err := ref.StatFile(ctx, gwclient.StatRequest{Path: filename})
+				assert.NilError(t, err, "expected zip %s", filename)
+				assert.Equal(t, stat.Path, filepath.Base(filename))
+			}
+		})
+	})
+
+	t.Run("empty package is rejected", func(t *testing.T) {
+		t.Parallel()
+		ctx := startTestSpan(ctx, t)
+		spec := newSpec()
+		// Add a subpackage with no artifacts; this should fail the build since
+		// it would produce an empty zip.
+		tgt := spec.Targets[targetKey]
+		tgt.Packages["empty"] = dalec.SubPackage{Description: "no artifacts here"}
+		spec.Targets[targetKey] = tgt
+
+		testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
+			sr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget("windowscross/zip"))
+			_, err := gwc.Solve(ctx, sr)
+			assert.ErrorContains(t, err, "no artifacts")
+		})
 	})
 }
 

--- a/website/docs/targets.md
+++ b/website/docs/targets.md
@@ -190,6 +190,72 @@ targets:
       qux:
 ```
 
+### Subpackages
+
+Subpackages (also called supplemental packages) let a single build produce more
+than one installable package. This is useful when you want to split build
+outputs into separate packages — for example a main runtime package plus a
+`-devel` package for headers, or a separate package for systemd units — without
+running the build more than once.
+
+Subpackages are defined per target under the `packages` field. Each entry is
+keyed by a short name; by default the produced package is named
+`<primary-package>-<key>`. All subpackages share the primary package's build
+steps, sources, version, revision, license, vendor, and website — these cannot
+be overridden. Each subpackage selects its own [artifacts](artifacts.md) and may
+declare its own metadata.
+
+```yaml
+name: foo
+
+targets:
+  azlinux3:
+    artifacts:
+      binaries:
+        bin/foo:
+    packages:
+      # Produces a package named "foo-devel".
+      devel:
+        description: Development files for foo
+        artifacts:
+          headers:
+            include/foo.h:
+        dependencies:
+          runtime:
+            foo:
+      # "name" overrides the default "foo-<key>" naming.
+      service:
+        name: foo-systemd
+        description: systemd units for foo
+        artifacts:
+          systemd:
+            units:
+              foo.service:
+                enable: true
+```
+
+Each subpackage supports the following fields:
+
+- `name`: Override the default `<primary-package>-<key>` package name.
+- `description` (required): Package description/summary. Both RPM and Debian
+  require this for every subpackage.
+- `artifacts`: The build outputs that go into this package. Subpackage artifacts
+  are self-contained — nothing is inherited from the primary package, so an
+  artifact placed in a subpackage is not also shipped by the primary package.
+- `dependencies`: Only `runtime` and `recommends` are allowed. Build
+  dependencies are shared with the primary package and cannot be set here.
+- `conflicts`, `provides`, `replaces`: Per-package metadata, equivalent to the
+  [primary package fields](#target-defined-package-metadata).
+
+Install-time scriptlet requirements are derived automatically from the
+subpackage's own artifacts. For example, a subpackage that ships enabled systemd
+units gets the appropriate `systemd` install-time requirements, and one that
+defines users or groups pulls in the tools needed to create them — independently
+of the primary package.
+
+Subpackage names must be unique within a target and must not collide with the
+primary package name.
+
 ## Special considerations
 
 ### Windows

--- a/website/docs/targets.md
+++ b/website/docs/targets.md
@@ -256,6 +256,17 @@ of the primary package.
 Subpackage names must be unique within a target and must not collide with the
 primary package name.
 
+On RPM and deb targets, a single package build (`<distro>/rpm`, `<distro>/deb`)
+produces all packages — the primary package plus every subpackage defined for
+the target — just like `rpmbuild` and `dpkg-buildpackage` emit all subpackages
+from one invocation. On the `windowscross/zip` target each package is emitted as
+its own `<name>_<version>-<revision>_<arch>.zip`. Because a zip must contain
+something, the `windowscross/zip` target errors if any package (primary or
+subpackage) resolves to no artifacts; on RPM and deb an artifact-less package is
+allowed (for example a metapackage that only declares dependencies). The
+`windowscross` container target installs the binaries from every package into
+the image.
+
 ## Special considerations
 
 ### Windows


### PR DESCRIPTION
Adds **subpackages** (supplemental packages): a single build can produce multiple installable packages, defined per target under a `packages` field. Each subpackage shares the primary's build (steps, sources, version, license, …) and selects its own artifacts.

- **RPM**: emits per-subpackage `%package`/`%files` sections.
- **Debian**: emits extra `Package:` stanzas with per-package install/maintainer scripts and `dh_installsystemd` overrides.
- **windowscross**: one zip per package; the container target installs binaries from all packages.

Artifacts are self-contained — anything placed in a subpackage isn't also shipped by the primary. Install-time scriptlet requirements (systemd, users/groups) are derived per subpackage.

Closes #607