### PR TITLE
targets: support BuildKit proxy package installs

### DIFF
--- a/frontend/gateway.go
+++ b/frontend/gateway.go
@@ -107,6 +107,7 @@ func SourceOptFromUIClient(ctx context.Context, c gwclient.Client, dc *dockerui.
 		TargetPlatform: platform,
 		Resolver:       c,
 		Forward:        ForwarderFromClient(ctx, c),
+		BuildArgs:      dalec.DuplicateMap(dc.BuildArgs),
 		GetContext: func(ref string, opts ...llb.LocalOption) (*llb.State, error) {
 			if ref == dockerui.DefaultLocalNameContext {
 				return dc.MainContext(ctx, opts...)

--- a/frontend/gateway.go
+++ b/frontend/gateway.go
@@ -107,7 +107,6 @@ func SourceOptFromUIClient(ctx context.Context, c gwclient.Client, dc *dockerui.
 		TargetPlatform: platform,
 		Resolver:       c,
 		Forward:        ForwarderFromClient(ctx, c),
-		BuildArgs:      dalec.DuplicateMap(dc.BuildArgs),
 		GetContext: func(ref string, opts ...llb.LocalOption) (*llb.State, error) {
 			if ref == dockerui.DefaultLocalNameContext {
 				return dc.MainContext(ctx, opts...)
@@ -129,6 +128,9 @@ func SourceOptFromUIClient(ctx context.Context, c gwclient.Client, dc *dockerui.
 			return st, err
 		},
 		GitCredHelperOpt: withCredHelper(c),
+	}
+	if dc != nil {
+		sOpt.BuildArgs = dalec.DuplicateMap(dc.BuildArgs)
 	}
 
 	sOpt.SourceFilter = sync.OnceValues(func() (dalec.SourceFilterConfig, error) {

--- a/frontend/router_test.go
+++ b/frontend/router_test.go
@@ -12,6 +12,7 @@ import (
 	bktargets "github.com/moby/buildkit/frontend/subrequests/targets"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/opencontainers/go-digest"
+	"github.com/project-dalec/dalec"
 )
 
 func TestRouter(t *testing.T) {
@@ -219,6 +220,25 @@ type stubOpt func(*stubClient)
 func withStubOptTarget(t string) stubOpt {
 	return func(c *stubClient) {
 		c.opts[keyTarget] = t
+	}
+}
+
+func withStubBuildArg(k, v string) stubOpt {
+	return func(c *stubClient) {
+		c.opts["build-arg:"+k] = v
+	}
+}
+
+func TestSourceOptFromClientCopiesDisableProxyBuildArg(t *testing.T) {
+	client := newStubClient(withStubBuildArg(dalec.BuildArgDalecDisableProxyConfig, "1"))
+
+	sOpt, err := SourceOptFromClient(context.Background(), client, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !sOpt.DisableProxyConfig() {
+		t.Fatal("expected DALEC_DISABLE_PROXY_CONFIG build arg to disable proxy config")
 	}
 }
 

--- a/generator_nodemodules.go
+++ b/generator_nodemodules.go
@@ -3,11 +3,66 @@ package dalec
 import (
 	"context"
 	"path/filepath"
+	"strings"
 
 	"github.com/goccy/go-yaml/ast"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/pkg/errors"
 )
+
+const npmProxyConfigScript = `
+configure_npm_proxy() {
+	restore_xtrace=0
+	case "$-" in
+		*x*) set +x; restore_xtrace=1 ;;
+	esac
+	restore_npm_xtrace() {
+		if [ "${restore_xtrace}" = "1" ]; then
+			set -x
+		fi
+	}
+
+	if [ "${DALEC_DISABLE_PROXY_CONFIG:-}" = "1" ]; then
+		restore_npm_xtrace
+		return 0
+	fi
+
+	http_proxy_value="${HTTP_PROXY:-${http_proxy:-}}"
+	https_proxy_value="${HTTPS_PROXY:-${https_proxy:-}}"
+	no_proxy_value="${NO_PROXY:-${no_proxy:-}}"
+	if [ -z "${http_proxy_value}" ] && [ -z "${https_proxy_value}" ]; then
+		restore_npm_xtrace
+		return 0
+	fi
+
+	if [ -n "${http_proxy_value}" ]; then
+		export npm_config_proxy="${http_proxy_value}"
+	fi
+	if [ -n "${https_proxy_value}" ]; then
+		export npm_config_https_proxy="${https_proxy_value}"
+	fi
+	if [ -n "${no_proxy_value}" ]; then
+		export npm_config_noproxy="${no_proxy_value}"
+	fi
+
+	for ca_bundle in \
+		/etc/ssl/certs/ca-certificates.crt \
+		/etc/pki/tls/certs/ca-bundle.crt \
+		/etc/ssl/ca-bundle.pem \
+		/etc/pki/tls/cacert.pem \
+		/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem \
+		/etc/ssl/cert.pem
+	do
+		if [ -f "${ca_bundle}" ]; then
+			export NODE_EXTRA_CA_CERTS="${ca_bundle}"
+			export npm_config_cafile="${ca_bundle}"
+			break
+		fi
+	done
+
+	restore_npm_xtrace
+}
+`
 
 func (s *Source) isNodeMod() bool {
 	for _, gen := range s.Generate {
@@ -28,7 +83,15 @@ func (s *Spec) HasNodeMods() bool {
 	return false
 }
 
-func withNodeMod(g *SourceGenerator, worker llb.State, name string, opts ...llb.ConstraintsOpt) llb.StateOption {
+func nodeProxyConfig(sOpt SourceOpts) llb.RunOption {
+	return RunOptFunc(func(ei *llb.ExecInfo) {
+		if sOpt.DisableProxyConfig() {
+			llb.AddEnv(BuildArgDalecDisableProxyConfig, "1").SetRunOption(ei)
+		}
+	})
+}
+
+func withNodeMod(g *SourceGenerator, sOpt SourceOpts, worker llb.State, name string, opts ...llb.ConstraintsOpt) llb.StateOption {
 	return func(in llb.State) llb.State {
 		workDir := "/work/src"
 		joinedWorkDir := filepath.Join(workDir, name, g.Subpath)
@@ -48,18 +111,17 @@ func withNodeMod(g *SourceGenerator, worker llb.State, name string, opts ...llb.
 			// without having to do an additional copy to move the files around.
 
 			installPath := filepath.Join(installBasePath, name, g.Subpath, path)
-			// Build an explicit argv (no shell) so each value is passed as a
-			// single literal argument. Running through `sh -c` would let
-			// characters in the registry URL such as &, ;, or $ be interpreted
-			// as shell syntax, truncating the value or executing unintended
-			// commands.
-			args := []string{"npm", "install", "--prefix", installPath}
+			// The proxy setup must run in a shell so its environment changes reach
+			// npm. Quote user-controlled values before embedding them in that shell
+			// command so registry URLs cannot be interpreted as shell syntax.
+			installCmd := npmProxyConfigScript + "\nconfigure_npm_proxy\nnpm install --prefix " + shellQuote(installPath)
 			if g.NodeMod.Registry != "" {
-				args = append(args, "--registry="+g.NodeMod.Registry)
+				installCmd += " --registry=" + shellQuote(g.NodeMod.Registry)
 			}
 
 			st := worker.Run(
-				llb.Args(args),
+				ShArgs(installCmd),
+				nodeProxyConfig(sOpt),
 				llb.Dir(filepath.Join(joinedWorkDir, path)),
 				WithConstraints(opts...),
 				llb.AddMount(workDir, in, llb.Readonly),
@@ -71,6 +133,10 @@ func withNodeMod(g *SourceGenerator, worker llb.State, name string, opts ...llb.
 		}
 		return MergeAtPath(llb.Scratch(), append(states, in), "/", opts...)
 	}
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
 }
 
 func (s *Spec) nodeModSources() map[string]Source {
@@ -109,7 +175,7 @@ func (s *Spec) NodeModDeps(sOpt SourceOpts, worker llb.State, opts ...llb.Constr
 			if gen.NodeMod == nil {
 				continue
 			}
-			merged = merged.With(withNodeMod(gen, worker, key, opts...))
+			merged = merged.With(withNodeMod(gen, sOpt, worker, key, opts...))
 		}
 		result[key] = merged.With(sourceFilterAtPath(sOpt, key, opts...))
 	}

--- a/generator_nodemodules_test.go
+++ b/generator_nodemodules_test.go
@@ -2,36 +2,31 @@ package dalec
 
 import (
 	"context"
+	"os/exec"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/moby/buildkit/client/llb"
 	"github.com/project-dalec/dalec/internal/test"
 	"gotest.tools/v3/assert"
-	"gotest.tools/v3/assert/cmp"
 )
 
 func TestNodeModRegistry(t *testing.T) {
 	t.Parallel()
 
-	t.Run("registry is passed as a single literal arg without a shell", func(t *testing.T) {
+	t.Run("registry is shell-quoted", func(t *testing.T) {
 		t.Parallel()
-		// URL deliberately contains shell metacharacters (& and $). If the
-		// command were built with sh -c, these would be interpreted by the
-		// shell and truncate the value or run unintended commands. As an argv
-		// element the URL must survive verbatim.
-		const registry = "https://example.test/npm/?a=1&b=$c"
+		const registry = "https://example.test/npm/?a=1&b=$c'quoted"
 		args := nodeModInstallArgs(t.Context(), t, &GeneratorNodeMod{Registry: registry})
-		assert.Check(t, cmp.Contains(args, "--registry="+registry))
-		assert.Check(t, args[0] != "sh" && args[0] != "bash",
-			"expected npm to be invoked directly without a shell; got: %v", args)
+		assert.Assert(t, strings.Contains(strings.Join(args, " "), "--registry='https://example.test/npm/?a=1&b=$c'\"'\"'quoted'"), args)
 	})
 
 	t.Run("registry unset omits --registry flag", func(t *testing.T) {
 		t.Parallel()
 		args := nodeModInstallArgs(t.Context(), t, &GeneratorNodeMod{})
 		for _, a := range args {
-			assert.Check(t, !strings.HasPrefix(a, "--registry"),
+			assert.Assert(t, !strings.Contains(a, "--registry="),
 				"expected no --registry flag when Registry is unset; got: %v", args)
 		}
 	})
@@ -74,4 +69,78 @@ func nodeModInstallArgs(ctx context.Context, t *testing.T, gen *GeneratorNodeMod
 
 	t.Fatal("no npm install command found in generated LLB")
 	return nil
+}
+
+func TestConfigureNpmProxySetsProxyConfig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires a POSIX shell")
+	}
+
+	cmd := exec.Command("/bin/sh", "-c", npmProxyConfigScript+`
+configure_npm_proxy
+	printf 'proxy=%s\nhttps_proxy=%s\nnoproxy=%s\ncafile=%s\nextra_ca=%s\n' \
+	"${npm_config_proxy:-}" \
+	"${npm_config_https_proxy:-}" \
+	"${npm_config_noproxy:-}" \
+	"${npm_config_cafile:-}" \
+	"${NODE_EXTRA_CA_CERTS:-}"
+`)
+	cmd.Env = []string{
+		"PATH=/bin:/usr/bin",
+		"HTTP_PROXY=http://proxy.example:3128",
+		"HTTPS_PROXY=https://proxy.example:8443",
+		"NO_PROXY=localhost,127.0.0.1",
+	}
+
+	out, err := cmd.CombinedOutput()
+	assert.NilError(t, err, string(out))
+
+	config := string(out)
+	assert.Assert(t, strings.Contains(config, "proxy=http://proxy.example:3128\n"), config)
+	assert.Assert(t, strings.Contains(config, "https_proxy=https://proxy.example:8443\n"), config)
+	assert.Assert(t, strings.Contains(config, "noproxy=localhost,127.0.0.1\n"), config)
+	assert.Assert(t, strings.Contains(config, "cafile=/"), config)
+	assert.Assert(t, strings.Contains(config, "extra_ca=/"), config)
+}
+
+func TestConfigureNpmProxyDoesNotTraceProxyValues(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires a POSIX shell")
+	}
+
+	cmd := exec.Command("/bin/sh", "-c", "set -x\n"+npmProxyConfigScript+"\nconfigure_npm_proxy\n")
+	cmd.Env = []string{
+		"PATH=/bin:/usr/bin",
+		"HTTP_PROXY=http://user:secret@proxy.example:3128",
+	}
+
+	out, err := cmd.CombinedOutput()
+	assert.NilError(t, err, string(out))
+	assert.Assert(t, !strings.Contains(string(out), "secret"), string(out))
+}
+
+func TestConfigureNpmProxyDisabled(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires a POSIX shell")
+	}
+
+	cmd := exec.Command("/bin/sh", "-c", npmProxyConfigScript+`
+configure_npm_proxy
+	printf 'proxy=%s\nhttps_proxy=%s\nnoproxy=%s\ncafile=%s\nextra_ca=%s\n' \
+	"${npm_config_proxy:-}" \
+	"${npm_config_https_proxy:-}" \
+	"${npm_config_noproxy:-}" \
+	"${npm_config_cafile:-}" \
+	"${NODE_EXTRA_CA_CERTS:-}"
+`)
+	cmd.Env = []string{
+		"PATH=/bin:/usr/bin",
+		"HTTP_PROXY=http://proxy.example:3128",
+		"HTTPS_PROXY=https://proxy.example:8443",
+		"DALEC_DISABLE_PROXY_CONFIG=1",
+	}
+
+	out, err := cmd.CombinedOutput()
+	assert.NilError(t, err, string(out))
+	assert.Equal(t, string(out), "proxy=\nhttps_proxy=\nnoproxy=\ncafile=\nextra_ca=\n")
 }

--- a/load.go
+++ b/load.go
@@ -22,6 +22,12 @@ const (
 	// the target name.
 	KeyDalecTarget = "DALEC_TARGET"
 
+	// BuildArgDalecDisableProxyConfig disables DALEC-managed proxy configuration
+	// for tools that need explicit proxy/CA setup in BuildKit proxy network mode.
+	//
+	// This does not disable BuildKit's solve-level proxy network enforcement.
+	BuildArgDalecDisableProxyConfig = "DALEC_DISABLE_PROXY_CONFIG"
+
 	parseModeIgnoreComments = 0
 )
 
@@ -40,6 +46,8 @@ func knownArg(key string) bool {
 	case "DALEC_DISABLE_PASSTHROUGH":
 		return true
 	case "DALEC_DISABLE_SYMLINK":
+		return true
+	case BuildArgDalecDisableProxyConfig:
 		return true
 	case "DALEC_SKIP_SIGNING":
 		return true

--- a/source.go
+++ b/source.go
@@ -153,11 +153,16 @@ type SourceOpts struct {
 	Forward          ForwarderFunc
 	GetContext       func(string, ...llb.LocalOption) (*llb.State, error)
 	TargetPlatform   *ocispecs.Platform
+	BuildArgs        map[string]string
 	GitCredHelperOpt func() (llb.RunOption, error)
 	SourceFilter     func() (SourceFilterConfig, error)
 	// ExtraEnvs contains environment variables that source generators may use
 	// while preparing generated dependency sources.
 	ExtraEnvs map[string]string
+}
+
+func (s SourceOpts) DisableProxyConfig() bool {
+	return s.BuildArgs[BuildArgDalecDisableProxyConfig] == "1"
 }
 
 var errInvalidMountConfig = errors.New("invalid mount config")

--- a/targets/linux/deb/distro/container.go
+++ b/targets/linux/deb/distro/container.go
@@ -40,6 +40,7 @@ func (c *Config) BuildContainer(ctx context.Context, client gwclient.Client, sOp
 		baseImg = baseImg.Run(
 			dalec.WithConstraints(opts...),
 			InstallLocalPkg(basePackages(ctx, input), true, opts...),
+			aptProxyConfig(input.SOpt),
 			dalec.WithMountedAptCache(c.AptCachePrefix, opts...),
 		).Root()
 	}
@@ -47,6 +48,7 @@ func (c *Config) BuildContainer(ctx context.Context, client gwclient.Client, sOp
 	return baseImg.With(installPackagesInContainer(input, []llb.RunOption{
 		dalec.WithMountedAptCache(input.Config.AptCachePrefix, opts...),
 		InstallLocalPkg(debSt, true, opts...),
+		aptProxyConfig(input.SOpt),
 	}))
 }
 
@@ -167,6 +169,11 @@ func bootstrapContainer(input buildContainerInput) llb.State {
 
 	installScript := `#!/bin/sh
 set -exu
+
+` + aptProxyConfigScript + `
+
+configure_apt_proxy
+trap cleanup_apt_proxy EXIT
 
 rootfs=/tmp/rootfs
 apt_archives=/var/cache/apt/archives
@@ -299,6 +306,7 @@ done
 		extraRepos(input, opts...),
 		dalec.WithMountedAptCache(input.Config.AptCachePrefix, opts...),
 		llb.AddEnv("DEBIAN_FRONTEND", "noninteractive"),
+		aptProxyConfig(input.SOpt),
 		dalec.ShArgs("/tmp/install.sh"),
 		frontend.IgnoreCache(input.Client, targets.IgnoreCacheKeyContainer),
 	).AddMount("/tmp/rootfs", baseImageFromSpec(baseImg, input))

--- a/targets/linux/deb/distro/install.go
+++ b/targets/linux/deb/distro/install.go
@@ -11,6 +11,108 @@ import (
 	"github.com/project-dalec/dalec/packaging/linux/deb"
 )
 
+const aptProxyConfigScript = `
+cleanup_apt_proxy() {
+	if [ -n "${DALEC_APT_PROXY_CONFIG_ACTIVE:-}" ]; then
+		rm -f "${DALEC_APT_PROXY_CONFIG_ACTIVE}" 2>/dev/null || true
+		if [ "${APT_CONFIG:-}" = "${DALEC_APT_PROXY_CONFIG_ACTIVE}" ]; then
+			if [ "${DALEC_APT_PROXY_CONFIG_OLD_APT_CONFIG_WAS_SET:-0}" = "1" ]; then
+				export APT_CONFIG="${DALEC_APT_PROXY_CONFIG_OLD_APT_CONFIG}"
+			else
+				unset APT_CONFIG
+			fi
+		fi
+		unset DALEC_APT_PROXY_CONFIG_ACTIVE
+		unset DALEC_APT_PROXY_CONFIG_OLD_APT_CONFIG
+		unset DALEC_APT_PROXY_CONFIG_OLD_APT_CONFIG_WAS_SET
+	fi
+}
+
+configure_apt_proxy() {
+	restore_xtrace=0
+	case "$-" in
+		*x*) set +x; restore_xtrace=1 ;;
+	esac
+
+	if [ "${DALEC_DISABLE_PROXY_CONFIG:-}" = "1" ]; then
+		if [ "${restore_xtrace}" = "1" ]; then
+			set -x
+		fi
+		return 0
+	fi
+
+	http_proxy_value="${HTTP_PROXY:-${http_proxy:-}}"
+	https_proxy_value="${HTTPS_PROXY:-${https_proxy:-}}"
+	if [ -z "${http_proxy_value}" ] && [ -z "${https_proxy_value}" ]; then
+		if [ "${restore_xtrace}" = "1" ]; then
+			set -x
+		fi
+		return 0
+	fi
+
+	apt_proxy_conf="${DALEC_APT_PROXY_CONFIG:-/tmp/dalec/apt-proxy.conf}"
+	apt_proxy_conf_dir="${apt_proxy_conf%/*}"
+	if [ -n "${apt_proxy_conf_dir}" ] && [ "${apt_proxy_conf_dir}" != "${apt_proxy_conf}" ]; then
+		mkdir -p "${apt_proxy_conf_dir}"
+	fi
+
+	write_apt_conf_string() {
+		key="${1}"
+		value="${2}"
+		if [ -z "${value}" ]; then
+			return 0
+		fi
+		escaped_value="$(printf '%s' "${value}" | sed 's/[\\"]/\\&/g')"
+		printf '%s "%s";\n' "${key}" "${escaped_value}"
+	}
+
+	if [ -n "${APT_CONFIG+x}" ]; then
+		DALEC_APT_PROXY_CONFIG_OLD_APT_CONFIG="${APT_CONFIG}"
+		DALEC_APT_PROXY_CONFIG_OLD_APT_CONFIG_WAS_SET=1
+	else
+		unset DALEC_APT_PROXY_CONFIG_OLD_APT_CONFIG
+		DALEC_APT_PROXY_CONFIG_OLD_APT_CONFIG_WAS_SET=0
+	fi
+
+	rm -f "${apt_proxy_conf}"
+	(
+		umask 077
+		{
+		write_apt_conf_string 'Acquire::http::Proxy' "${http_proxy_value}"
+		write_apt_conf_string 'Acquire::https::Proxy' "${https_proxy_value}"
+		for ca_bundle in \
+			/etc/ssl/certs/ca-certificates.crt \
+			/etc/pki/tls/certs/ca-bundle.crt \
+			/etc/ssl/ca-bundle.pem \
+			/etc/pki/tls/cacert.pem \
+			/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem \
+			/etc/ssl/cert.pem
+		do
+			if [ -f "${ca_bundle}" ]; then
+				write_apt_conf_string 'Acquire::https::CaInfo' "${ca_bundle}"
+				break
+			fi
+		done
+		} > "${apt_proxy_conf}"
+	)
+
+	export APT_CONFIG="${apt_proxy_conf}"
+	DALEC_APT_PROXY_CONFIG_ACTIVE="${apt_proxy_conf}"
+
+	if [ "${restore_xtrace}" = "1" ]; then
+		set -x
+	fi
+}
+`
+
+func aptProxyConfig(sOpt dalec.SourceOpts) llb.RunOption {
+	return dalec.RunOptFunc(func(ei *llb.ExecInfo) {
+		if sOpt.DisableProxyConfig() {
+			llb.AddEnv(dalec.BuildArgDalecDisableProxyConfig, "1").SetRunOption(ei)
+		}
+	})
+}
+
 // AptInstall returns an [llb.RunOption] that uses apt to install the provided
 // packages.
 //
@@ -20,11 +122,15 @@ import (
 func AptInstall(packages []string, opts ...llb.ConstraintsOpt) llb.RunOption {
 	return dalec.RunOptFunc(func(ei *llb.ExecInfo) {
 		const installScript = `#!/usr/bin/env sh
-set -ex
+	set -ex
 
+	` + aptProxyConfigScript + `
 
-# Make sure any cached data from local repos is purged since this should not
-# be shared between builds.
+	configure_apt_proxy
+	trap cleanup_apt_proxy EXIT
+
+	# Make sure any cached data from local repos is purged since this should not
+	# be shared between builds.
 rm -f /var/lib/apt/lists/_*
 apt autoclean -y 
 
@@ -63,9 +169,11 @@ func AptInstallIntoRoot(rootfsPath string, packages []string, targetArch string,
 		ei.Constraints.Platform = &bp
 
 		const installScript = `#!/bin/sh
-set -eu
+	set -eu
 
-# Exit codes:
+	` + aptProxyConfigScript + `
+
+	# Exit codes:
 #   2 - Required environment variables missing
 #   3 - Target rootfs invalid / missing apt sources
 #   4 - Target rootfs dpkg arch mismatch
@@ -75,12 +183,14 @@ log() { echo "dalec(deb): $*" >&2; }
 
 ROOTFS="${DALEC_ROOTFS:-}"
 ARCH="${DALEC_TARGET_ARCH:-}"
-if [ -z "${ROOTFS}" ] || [ -z "${ARCH}" ]; then
-  log "DALEC_ROOTFS and DALEC_TARGET_ARCH must be set"
-  exit 2
-fi
+	if [ -z "${ROOTFS}" ] || [ -z "${ARCH}" ]; then
+	  log "DALEC_ROOTFS and DALEC_TARGET_ARCH must be set"
+	  exit 2
+	fi
+	configure_apt_proxy
+	trap cleanup_apt_proxy EXIT
 
-if [ -f "${ROOTFS}/var/lib/dpkg/arch" ]; then
+	if [ -f "${ROOTFS}/var/lib/dpkg/arch" ]; then
   native_arch="$(head -n1 "${ROOTFS}/var/lib/dpkg/arch" 2>/dev/null | tr -d '\n' || true)"
   if [ -n "${native_arch}" ] && [ "${native_arch}" != "${ARCH}" ]; then
     log "target rootfs dpkg arch (${native_arch}) != requested (${ARCH})"
@@ -192,7 +302,7 @@ cat > "${POLICY}" <<'EOF'
 exit 101
 EOF
 chmod +x "${POLICY}"
-trap 'rm -f "${POLICY}" 2>/dev/null || true' EXIT
+trap 'rm -f "${POLICY}" 2>/dev/null || true; cleanup_apt_proxy' EXIT
 
 chroot_configure() { chroot "${ROOTFS}" /usr/bin/dpkg --configure -a; }
 
@@ -252,9 +362,14 @@ func InstallLocalPkg(pkg llb.State, upgrade bool, opts ...llb.ConstraintsOpt) ll
 		// solution that will respect the constraints even if the solution involves
 		// pinning dependency packages to older versions.
 		const installScript = `#!/usr/bin/env sh
-set -ex
-# Make sure any cached data from local repos is purged since this should not
-# be shared between builds.
+	set -ex
+	` + aptProxyConfigScript + `
+
+	configure_apt_proxy
+	trap cleanup_apt_proxy EXIT
+
+	# Make sure any cached data from local repos is purged since this should not
+	# be shared between builds.
 rm -f /var/lib/apt/lists/_*
 apt autoclean -y
 
@@ -277,6 +392,7 @@ fi
 
 cleanup() {
 	exit_code=$?
+	cleanup_apt_proxy
 	if [ "${needs_cleanup}" = "1" ]; then
 		apt remove -y aptitude
 	fi
@@ -342,6 +458,7 @@ func (d *Config) InstallBuildDeps(ctx context.Context, sOpt dalec.SourceOpts, sp
 			dalec.WithConstraints(opts...),
 			customRepos,
 			InstallLocalPkg(pkg, false, opts...),
+			aptProxyConfig(sOpt),
 			dalec.WithMountedAptCache(d.AptCachePrefix, opts...),
 			deps.GetSourceLocation(in),
 		).Root()
@@ -364,6 +481,7 @@ func (d *Config) InstallTestDeps(sOpt dalec.SourceOpts, targetKey string, spec *
 		return in.Run(
 			dalec.WithConstraints(opts...),
 			AptInstall(dalec.SortMapKeys(deps), opts...),
+			aptProxyConfig(sOpt),
 			withRepos,
 			dalec.WithMountedAptCache(d.AptCachePrefix, opts...),
 			deps.GetSourceLocation(in),
@@ -380,10 +498,15 @@ func (d *Config) DownloadDeps(worker llb.State, sOpt dalec.SourceOpts, spec *dal
 
 	scriptPath := "/tmp/dalec/internal/deb/download.sh"
 	const scriptSrc = `#!/usr/bin/env bash
-set -euxo pipefail
-cd /output
+	set -euxo pipefail
+	cd /output
 
-# Make sure any cached data from local repos is purged since this should not
+	` + aptProxyConfigScript + `
+
+	configure_apt_proxy
+	trap cleanup_apt_proxy EXIT
+
+	# Make sure any cached data from local repos is purged since this should not
 # be shared between builds.
 rm -f /var/lib/apt/lists/_*
 apt autoclean -y
@@ -413,6 +536,7 @@ done
 		llb.AddMount(scriptPath, scriptFile, llb.SourcePath("download.sh"), llb.Readonly),
 		llb.AddMount("/var/lib/dpkg", llb.Scratch(), llb.Tmpfs()),
 		llb.AddEnv("DEBIAN_FRONTEND", "noninteractive"),
+		aptProxyConfig(sOpt),
 		dalec.WithMountedAptCache(d.AptCachePrefix, opts...),
 		dalec.WithConstraints(opts...),
 	).AddMount("/output", llb.Scratch())

--- a/targets/linux/deb/distro/install.go
+++ b/targets/linux/deb/distro/install.go
@@ -122,17 +122,17 @@ func aptProxyConfig(sOpt dalec.SourceOpts) llb.RunOption {
 func AptInstall(packages []string, opts ...llb.ConstraintsOpt) llb.RunOption {
 	return dalec.RunOptFunc(func(ei *llb.ExecInfo) {
 		const installScript = `#!/usr/bin/env sh
-	set -ex
+set -ex
 
-	` + aptProxyConfigScript + `
+` + aptProxyConfigScript + `
 
-	configure_apt_proxy
-	trap cleanup_apt_proxy EXIT
+configure_apt_proxy
+trap cleanup_apt_proxy EXIT
 
-	# Make sure any cached data from local repos is purged since this should not
-	# be shared between builds.
+# Make sure any cached data from local repos is purged since this should not
+# be shared between builds.
 rm -f /var/lib/apt/lists/_*
-apt autoclean -y 
+apt autoclean -y
 
 # Remove any previously failed attempts to get repo data
 rm -rf /var/lib/apt/lists/partial/*

--- a/targets/linux/deb/distro/install_test.go
+++ b/targets/linux/deb/distro/install_test.go
@@ -1,0 +1,116 @@
+package distro
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestConfigureAptProxyWritesConfig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires a POSIX shell")
+	}
+
+	conf := filepath.Join(t.TempDir(), "apt.conf")
+	cmd := exec.Command("/bin/sh", "-c", aptProxyConfigScript+"\nconfigure_apt_proxy\nprintf '%s' \"${APT_CONFIG}\"\n")
+	cmd.Env = []string{
+		"PATH=/bin:/usr/bin",
+		"HTTP_PROXY=http://proxy.example:3128",
+		"HTTPS_PROXY=https://proxy.example:8443",
+		"DALEC_APT_PROXY_CONFIG=" + conf,
+	}
+
+	out, err := cmd.CombinedOutput()
+	assert.NilError(t, err, string(out))
+	assert.Equal(t, string(out), conf)
+
+	dt, err := os.ReadFile(conf)
+	assert.NilError(t, err)
+
+	aptConf := string(dt)
+	assert.Assert(t, strings.Contains(aptConf, `Acquire::http::Proxy "http://proxy.example:3128";`), aptConf)
+	assert.Assert(t, strings.Contains(aptConf, `Acquire::https::Proxy "https://proxy.example:8443";`), aptConf)
+
+	info, err := os.Stat(conf)
+	assert.NilError(t, err)
+	assert.Equal(t, info.Mode().Perm(), os.FileMode(0o600))
+}
+
+func TestConfigureAptProxyDoesNotTraceProxyValues(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires a POSIX shell")
+	}
+
+	conf := filepath.Join(t.TempDir(), "apt.conf")
+	cmd := exec.Command("/bin/sh", "-c", "set -x\n"+aptProxyConfigScript+"\nconfigure_apt_proxy\n")
+	cmd.Env = []string{
+		"PATH=/bin:/usr/bin",
+		"HTTP_PROXY=http://user:secret@proxy.example:3128",
+		"DALEC_APT_PROXY_CONFIG=" + conf,
+	}
+
+	out, err := cmd.CombinedOutput()
+	assert.NilError(t, err, string(out))
+	assert.Assert(t, !strings.Contains(string(out), "secret"), string(out))
+}
+
+func TestCleanupAptProxyRemovesConfig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires a POSIX shell")
+	}
+
+	conf := filepath.Join(t.TempDir(), "apt.conf")
+	cmd := exec.Command("/bin/sh", "-c", aptProxyConfigScript+"\nconfigure_apt_proxy\ncleanup_apt_proxy\nif [ -n \"${APT_CONFIG:-}\" ] || [ -e \"${DALEC_APT_PROXY_CONFIG}\" ]; then exit 1; fi\n")
+	cmd.Env = []string{
+		"PATH=/bin:/usr/bin",
+		"HTTP_PROXY=http://proxy.example:3128",
+		"DALEC_APT_PROXY_CONFIG=" + conf,
+	}
+
+	out, err := cmd.CombinedOutput()
+	assert.NilError(t, err, string(out))
+}
+
+func TestCleanupAptProxyRestoresAptConfig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires a POSIX shell")
+	}
+
+	dir := t.TempDir()
+	conf := filepath.Join(dir, "apt.conf")
+	original := filepath.Join(dir, "original.conf")
+	cmd := exec.Command("/bin/sh", "-c", aptProxyConfigScript+"\nconfigure_apt_proxy\ncleanup_apt_proxy\nprintf '%s' \"${APT_CONFIG:-}\"\n")
+	cmd.Env = []string{
+		"PATH=/bin:/usr/bin",
+		"APT_CONFIG=" + original,
+		"HTTP_PROXY=http://proxy.example:3128",
+		"DALEC_APT_PROXY_CONFIG=" + conf,
+	}
+
+	out, err := cmd.CombinedOutput()
+	assert.NilError(t, err, string(out))
+	assert.Equal(t, string(out), original)
+}
+
+func TestConfigureAptProxyDisabled(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires a POSIX shell")
+	}
+
+	conf := filepath.Join(t.TempDir(), "apt.conf")
+	cmd := exec.Command("/bin/sh", "-c", aptProxyConfigScript+"\nconfigure_apt_proxy\nif [ -n \"${APT_CONFIG:-}\" ] || [ -e \"${DALEC_APT_PROXY_CONFIG}\" ]; then exit 1; fi\n")
+	cmd.Env = []string{
+		"PATH=/bin:/usr/bin",
+		"HTTP_PROXY=http://proxy.example:3128",
+		"DALEC_APT_PROXY_CONFIG=" + conf,
+		"DALEC_DISABLE_PROXY_CONFIG=1",
+	}
+
+	out, err := cmd.CombinedOutput()
+	assert.NilError(t, err, string(out))
+}

--- a/targets/linux/deb/distro/worker.go
+++ b/targets/linux/deb/distro/worker.go
@@ -187,6 +187,7 @@ func (cfg *Config) workerWithBuildPlatform(sOpt dalec.SourceOpts, buildPlat ocis
 		return targetBase.Run(
 			dalec.WithConstraints(append(opts, llb.Platform(targetPlat))...),
 			AptInstall(cfg.BuilderPackages, opts...),
+			aptProxyConfig(sOpt),
 			dalec.WithMountedAptCache(cfg.AptCachePrefix, opts...),
 		).Root()
 	}
@@ -205,6 +206,7 @@ func (cfg *Config) workerWithBuildPlatform(sOpt dalec.SourceOpts, buildPlat ocis
 		dalec.WithConstraints(append(opts, llb.Platform(buildPlat))...),
 		llb.AddMount(rootfsMount, targetBase),
 		AptInstallIntoRoot(rootfsMount, cfg.BuilderPackages, targetArch, buildPlat),
+		aptProxyConfig(sOpt),
 		dalec.WithMountedAptCache(cacheKey),
 	)
 
@@ -228,6 +230,7 @@ func (cfg *Config) SysextWorker(sOpts dalec.SourceOpts, opts ...llb.ConstraintsO
 		return worker.Run(
 			dalec.WithConstraints(append(opts, llb.Platform(targetPlat))...),
 			AptInstall([]string{"erofs-utils"}, opts...),
+			aptProxyConfig(sOpts),
 			dalec.WithMountedAptCache(cfg.AptCachePrefix),
 		).Root()
 	}
@@ -251,6 +254,7 @@ func (cfg *Config) SysextWorker(sOpts dalec.SourceOpts, opts ...llb.ConstraintsO
 		dalec.WithConstraints(append(opts, llb.Platform(buildPlat))...),
 		llb.AddMount(rootfsMount, worker),
 		AptInstallIntoRoot(rootfsMount, []string{"erofs-utils"}, targetArch, buildPlat),
+		aptProxyConfig(sOpts),
 		dalec.WithMountedAptCache(cacheKey),
 	)
 

--- a/targets/linux/rpm/distro/container.go
+++ b/targets/linux/rpm/distro/container.go
@@ -33,6 +33,7 @@ func (cfg *Config) BuildContainer(ctx context.Context, client gwclient.Client, s
 	importRepos := []DnfInstallOpt{
 		DnfWithMounts(repoMounts),
 		DnfImportKeys(keyPaths),
+		DnfWithSourceOpts(sOpt),
 		DnfInstallWithConstraints(opts),
 	}
 

--- a/targets/linux/rpm/distro/dnf_install.go
+++ b/targets/linux/rpm/distro/dnf_install.go
@@ -38,6 +38,8 @@ type dnfInstallConfig struct {
 	includeDocs bool
 
 	forceArch string
+
+	disableProxyConfig bool
 }
 
 type DnfInstallOpt func(*dnfInstallConfig)
@@ -79,6 +81,12 @@ func DnfForceArch(arch string) DnfInstallOpt {
 func IncludeDocs(v bool) DnfInstallOpt {
 	return func(cfg *dnfInstallConfig) {
 		cfg.includeDocs = v
+	}
+}
+
+func DnfWithSourceOpts(sOpt dalec.SourceOpts) DnfInstallOpt {
+	return func(cfg *dnfInstallConfig) {
+		cfg.disableProxyConfig = sOpt.DisableProxyConfig()
 	}
 }
 
@@ -133,6 +141,97 @@ rpm --import "${key_path}"
 	return importScript
 }
 
+const dnfProxyConfigScript = `
+cleanup_dnf_proxy() {
+	if [ -n "${DALEC_DNF_PROXY_TRUST_BUNDLE_ACTIVE:-}" ]; then
+		if [ -n "${DALEC_DNF_PROXY_TRUST_BUNDLE_BACKUP:-}" ] && [ -f "${DALEC_DNF_PROXY_TRUST_BUNDLE_BACKUP}" ]; then
+			cp -p "${DALEC_DNF_PROXY_TRUST_BUNDLE_BACKUP}" "${DALEC_DNF_PROXY_TRUST_BUNDLE_ACTIVE}" 2>/dev/null || true
+			rm -f "${DALEC_DNF_PROXY_TRUST_BUNDLE_BACKUP}" 2>/dev/null || true
+		fi
+		unset DALEC_DNF_PROXY_TRUST_BUNDLE_ACTIVE
+		unset DALEC_DNF_PROXY_TRUST_BUNDLE_BACKUP
+	fi
+}
+
+sync_dnf_proxy_trust_bundle() {
+	source_bundle="${1}"
+	trust_bundle="${DALEC_RPM_PROXY_TRUST_BUNDLE:-/etc/pki/tls/certs/ca-bundle.trust.crt}"
+	if [ ! -f "${source_bundle}" ] || [ ! -f "${trust_bundle}" ]; then
+		return 0
+	fi
+	if [ "${source_bundle}" = "${trust_bundle}" ]; then
+		return 0
+	fi
+	if ! grep -q '# buildkit proxy CA begin' "${source_bundle}" 2>/dev/null; then
+		return 0
+	fi
+	if grep -q '# buildkit proxy CA begin' "${trust_bundle}" 2>/dev/null; then
+		return 0
+	fi
+
+	mkdir -p /tmp/dalec
+	backup="${DALEC_RPM_PROXY_TRUST_BUNDLE_BACKUP:-/tmp/dalec/dnf-proxy-ca-bundle.trust.crt.bak}"
+	cp -p "${trust_bundle}" "${backup}"
+	sed -n '/# buildkit proxy CA begin/,/# buildkit proxy CA end/p' "${source_bundle}" >> "${trust_bundle}"
+	DALEC_DNF_PROXY_TRUST_BUNDLE_ACTIVE="${trust_bundle}"
+	DALEC_DNF_PROXY_TRUST_BUNDLE_BACKUP="${backup}"
+}
+
+configure_dnf_proxy() {
+	restore_xtrace=0
+	case "$-" in
+		*x*) set +x; restore_xtrace=1 ;;
+	esac
+
+	if [ "${DALEC_DISABLE_PROXY_CONFIG:-}" = "1" ]; then
+		if [ "${restore_xtrace}" = "1" ]; then
+			set -x
+		fi
+		return 0
+	fi
+
+	http_proxy_value="${HTTP_PROXY:-${http_proxy:-}}"
+	https_proxy_value="${HTTPS_PROXY:-${https_proxy:-}}"
+	if [ -z "${http_proxy_value}" ] && [ -z "${https_proxy_value}" ]; then
+		if [ "${restore_xtrace}" = "1" ]; then
+			set -x
+		fi
+		return 0
+	fi
+
+	dnf_proxy_ca_bundle="${DALEC_RPM_PROXY_CA_BUNDLE:-}"
+	if [ -n "${dnf_proxy_ca_bundle}" ] && [ ! -f "${dnf_proxy_ca_bundle}" ]; then
+		dnf_proxy_ca_bundle=""
+	fi
+	if [ -z "${dnf_proxy_ca_bundle}" ]; then
+		for ca_bundle in \
+			/etc/ssl/certs/ca-certificates.crt \
+			/etc/pki/tls/certs/ca-bundle.crt \
+			/etc/ssl/ca-bundle.pem \
+			/etc/pki/tls/cacert.pem \
+			/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem \
+			/etc/ssl/cert.pem
+		do
+			if [ -f "${ca_bundle}" ]; then
+				dnf_proxy_ca_bundle="${ca_bundle}"
+				break
+			fi
+		done
+	fi
+
+	if [ -n "${dnf_proxy_ca_bundle}" ]; then
+		sync_dnf_proxy_trust_bundle "${dnf_proxy_ca_bundle}"
+		install_flags="${install_flags} --setopt=sslverify=1 --setopt=sslcacert=${dnf_proxy_ca_bundle}"
+		export SSL_CERT_FILE="${dnf_proxy_ca_bundle}"
+		export CURL_CA_BUNDLE="${dnf_proxy_ca_bundle}"
+	fi
+
+	if [ "${restore_xtrace}" = "1" ]; then
+		set -x
+	fi
+}
+`
+
 func dnfCommand(cfg *dnfInstallConfig, releaseVer string, exe string, dnfSubCmd []string, dnfArgs []string) llb.RunOption {
 	const importKeysPath = "/tmp/dalec/internal/dnf/import-keys.sh"
 
@@ -145,6 +244,8 @@ func dnfCommand(cfg *dnfInstallConfig, releaseVer string, exe string, dnfSubCmd 
 	forceArch := cfg.forceArch
 	installScriptDt := `#!/usr/bin/env bash
 set -eux -o pipefail
+
+` + dnfProxyConfigScript + `
 
 import_keys_path="` + importKeysPath + `"
 cmd="` + exe + `"
@@ -170,6 +271,9 @@ if [ -n "$force_arch" ]; then
 	fi
 	install_flags="$install_flags --forcearch=$force_arch"
 fi
+
+configure_dnf_proxy
+trap cleanup_dnf_proxy EXIT
 
 $cmd $dnf_sub_cmd $install_flags "${@}"
 `
@@ -201,11 +305,14 @@ $cmd $dnf_sub_cmd $install_flags "${@}"
 
 	runOpts = append(runOpts, llb.Args(cmd))
 	runOpts = append(runOpts, cfg.mounts...)
+	if cfg.disableProxyConfig {
+		runOpts = append(runOpts, llb.AddEnv(dalec.BuildArgDalecDisableProxyConfig, "1"))
+	}
 
 	return dalec.WithRunOptions(runOpts...)
 }
 
-func (cfg *Config) InstallIntoRoot(rootfsPath string, pkgs []string, targetArch string, buildPlat ocispecs.Platform) llb.RunOption {
+func (cfg *Config) InstallIntoRoot(rootfsPath string, pkgs []string, targetArch string, buildPlat ocispecs.Platform, sOpt dalec.SourceOpts) llb.RunOption {
 	return dalec.RunOptFunc(func(ei *llb.ExecInfo) {
 		// Ensure the package manager runs on the build/executor platform (native),
 		// while installing into the mounted target rootfs via --installroot.
@@ -215,6 +322,7 @@ func (cfg *Config) InstallIntoRoot(rootfsPath string, pkgs []string, targetArch 
 		installOpts := []DnfInstallOpt{
 			DnfAtRoot(rootfsPath),
 			DnfForceArch(targetArch),
+			DnfWithSourceOpts(sOpt),
 			DnfInstallWithConstraints([]llb.ConstraintsOpt{dalec.WithConstraint(&ei.Constraints)}),
 		}
 
@@ -305,6 +413,7 @@ func (cfg *Config) WithDeps(sOpt dalec.SourceOpts, targetKey, pkgName string, de
 			DnfWithMounts(llb.AddMount(rpmMountDir, rpmDir, llb.SourcePath("/RPMS"), llb.Readonly)),
 			DnfWithMounts(repoMounts),
 			DnfImportKeys(keyPaths),
+			DnfWithSourceOpts(sOpt),
 			DnfInstallWithConstraints(opts),
 		}
 
@@ -327,6 +436,7 @@ func (cfg *Config) DownloadDeps(sOpt dalec.SourceOpts, spec *dalec.Spec, targetK
 	worker := cfg.Worker(sOpt, dalec.Platform(sOpt.TargetPlatform), dalec.WithConstraints(opts...))
 
 	installOpts := []DnfInstallOpt{
+		DnfWithSourceOpts(sOpt),
 		DnfInstallWithConstraints(opts),
 	}
 

--- a/targets/linux/rpm/distro/dnf_install.go
+++ b/targets/linux/rpm/distro/dnf_install.go
@@ -144,12 +144,12 @@ rpm --import "${key_path}"
 const dnfProxyConfigScript = `
 cleanup_dnf_proxy() {
 	if [ -n "${DALEC_DNF_PROXY_TRUST_BUNDLE_ACTIVE:-}" ]; then
-		if [ -n "${DALEC_DNF_PROXY_TRUST_BUNDLE_BACKUP:-}" ] && [ -f "${DALEC_DNF_PROXY_TRUST_BUNDLE_BACKUP}" ]; then
-			cp -p "${DALEC_DNF_PROXY_TRUST_BUNDLE_BACKUP}" "${DALEC_DNF_PROXY_TRUST_BUNDLE_ACTIVE}" 2>/dev/null || true
-			rm -f "${DALEC_DNF_PROXY_TRUST_BUNDLE_BACKUP}" 2>/dev/null || true
+		tmp="$(mktemp)"
+		if sed '/# buildkit proxy CA begin/,/# buildkit proxy CA end/d' "${DALEC_DNF_PROXY_TRUST_BUNDLE_ACTIVE}" > "${tmp}" 2>/dev/null; then
+			cat "${tmp}" > "${DALEC_DNF_PROXY_TRUST_BUNDLE_ACTIVE}" 2>/dev/null || true
 		fi
+		rm -f "${tmp}" 2>/dev/null || true
 		unset DALEC_DNF_PROXY_TRUST_BUNDLE_ACTIVE
-		unset DALEC_DNF_PROXY_TRUST_BUNDLE_BACKUP
 	fi
 }
 
@@ -169,12 +169,8 @@ sync_dnf_proxy_trust_bundle() {
 		return 0
 	fi
 
-	mkdir -p /tmp/dalec
-	backup="${DALEC_RPM_PROXY_TRUST_BUNDLE_BACKUP:-/tmp/dalec/dnf-proxy-ca-bundle.trust.crt.bak}"
-	cp -p "${trust_bundle}" "${backup}"
 	sed -n '/# buildkit proxy CA begin/,/# buildkit proxy CA end/p' "${source_bundle}" >> "${trust_bundle}"
 	DALEC_DNF_PROXY_TRUST_BUNDLE_ACTIVE="${trust_bundle}"
-	DALEC_DNF_PROXY_TRUST_BUNDLE_BACKUP="${backup}"
 }
 
 configure_dnf_proxy() {

--- a/targets/linux/rpm/distro/dnf_install_test.go
+++ b/targets/linux/rpm/distro/dnf_install_test.go
@@ -1,0 +1,129 @@
+package distro
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestConfigureDnfProxyAddsCACertOptions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires a POSIX shell")
+	}
+
+	caBundle := filepath.Join(t.TempDir(), "ca-bundle.pem")
+	err := os.WriteFile(caBundle, []byte("test ca"), 0o600)
+	assert.NilError(t, err)
+
+	cmd := exec.Command("/bin/bash", "-c", dnfProxyConfigScript+`
+install_flags="-y"
+configure_dnf_proxy
+printf '%s\n%s\n%s\n' "${install_flags}" "${SSL_CERT_FILE:-}" "${CURL_CA_BUNDLE:-}"
+`)
+	cmd.Env = []string{
+		"PATH=/bin:/usr/bin",
+		"HTTPS_PROXY=http://proxy.example:3128",
+		"DALEC_RPM_PROXY_CA_BUNDLE=" + caBundle,
+	}
+
+	out, err := cmd.CombinedOutput()
+	assert.NilError(t, err, string(out))
+
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	assert.Equal(t, len(lines), 3, string(out))
+	assert.Assert(t, strings.Contains(lines[0], "--setopt=sslverify=1"), lines[0])
+	assert.Assert(t, strings.Contains(lines[0], "--setopt=sslcacert="+caBundle), lines[0])
+	assert.Equal(t, lines[1], caBundle)
+	assert.Equal(t, lines[2], caBundle)
+}
+
+func TestConfigureDnfProxyDoesNotTraceProxyValues(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires a POSIX shell")
+	}
+
+	caBundle := filepath.Join(t.TempDir(), "ca-bundle.pem")
+	err := os.WriteFile(caBundle, []byte("test ca"), 0o600)
+	assert.NilError(t, err)
+
+	cmd := exec.Command("/bin/bash", "-c", "set -x\n"+dnfProxyConfigScript+`
+install_flags="-y"
+configure_dnf_proxy
+`)
+	cmd.Env = []string{
+		"PATH=/bin:/usr/bin",
+		"HTTP_PROXY=http://user:secret@proxy.example:3128",
+		"DALEC_RPM_PROXY_CA_BUNDLE=" + caBundle,
+	}
+
+	out, err := cmd.CombinedOutput()
+	assert.NilError(t, err, string(out))
+	assert.Assert(t, !strings.Contains(string(out), "secret"), string(out))
+}
+
+func TestCleanupDnfProxyRestoresTrustBundle(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires a POSIX shell")
+	}
+
+	dir := t.TempDir()
+	caBundle := filepath.Join(dir, "ca-bundle.pem")
+	trustBundle := filepath.Join(dir, "ca-bundle.trust.crt")
+	err := os.WriteFile(caBundle, []byte(`system ca
+# buildkit proxy CA begin
+proxy ca
+# buildkit proxy CA end
+`), 0o600)
+	assert.NilError(t, err)
+	err = os.WriteFile(trustBundle, []byte("trust ca\n"), 0o600)
+	assert.NilError(t, err)
+
+	cmd := exec.Command("/bin/bash", "-c", dnfProxyConfigScript+`
+install_flags="-y"
+configure_dnf_proxy
+grep -q 'buildkit proxy CA begin' "${DALEC_RPM_PROXY_TRUST_BUNDLE}"
+cleanup_dnf_proxy
+if grep -q 'buildkit proxy CA begin' "${DALEC_RPM_PROXY_TRUST_BUNDLE}"; then exit 1; fi
+`)
+	cmd.Env = []string{
+		"PATH=/bin:/usr/bin",
+		"HTTP_PROXY=http://proxy.example:3128",
+		"DALEC_RPM_PROXY_CA_BUNDLE=" + caBundle,
+		"DALEC_RPM_PROXY_TRUST_BUNDLE=" + trustBundle,
+		"DALEC_RPM_PROXY_TRUST_BUNDLE_BACKUP=" + filepath.Join(dir, "backup"),
+	}
+
+	out, err := cmd.CombinedOutput()
+	assert.NilError(t, err, string(out))
+}
+
+func TestConfigureDnfProxyDisabled(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires a POSIX shell")
+	}
+
+	caBundle := filepath.Join(t.TempDir(), "ca-bundle.pem")
+	err := os.WriteFile(caBundle, []byte("test ca"), 0o600)
+	assert.NilError(t, err)
+
+	cmd := exec.Command("/bin/bash", "-c", dnfProxyConfigScript+`
+install_flags="-y"
+configure_dnf_proxy
+if [ "${install_flags}" != "-y" ]; then exit 1; fi
+if [ -n "${SSL_CERT_FILE:-}" ] || [ -n "${CURL_CA_BUNDLE:-}" ]; then exit 1; fi
+`)
+	cmd.Env = []string{
+		"PATH=/bin:/usr/bin",
+		"HTTP_PROXY=http://proxy.example:3128",
+		"DALEC_RPM_PROXY_CA_BUNDLE=" + caBundle,
+		"DALEC_DISABLE_PROXY_CONFIG=1",
+	}
+
+	out, err := cmd.CombinedOutput()
+	assert.NilError(t, err, string(out))
+}

--- a/targets/linux/rpm/distro/dnf_install_test.go
+++ b/targets/linux/rpm/distro/dnf_install_test.go
@@ -66,7 +66,7 @@ configure_dnf_proxy
 	assert.Assert(t, !strings.Contains(string(out), "secret"), string(out))
 }
 
-func TestCleanupDnfProxyRestoresTrustBundle(t *testing.T) {
+func TestCleanupDnfProxyRemovesOnlyProxyCABlock(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("requires a POSIX shell")
 	}
@@ -87,15 +87,16 @@ proxy ca
 install_flags="-y"
 configure_dnf_proxy
 grep -q 'buildkit proxy CA begin' "${DALEC_RPM_PROXY_TRUST_BUNDLE}"
+printf 'new ca\n' >> "${DALEC_RPM_PROXY_TRUST_BUNDLE}"
 cleanup_dnf_proxy
 if grep -q 'buildkit proxy CA begin' "${DALEC_RPM_PROXY_TRUST_BUNDLE}"; then exit 1; fi
+grep -q 'new ca' "${DALEC_RPM_PROXY_TRUST_BUNDLE}"
 `)
 	cmd.Env = []string{
 		"PATH=/bin:/usr/bin",
 		"HTTP_PROXY=http://proxy.example:3128",
 		"DALEC_RPM_PROXY_CA_BUNDLE=" + caBundle,
 		"DALEC_RPM_PROXY_TRUST_BUNDLE=" + trustBundle,
-		"DALEC_RPM_PROXY_TRUST_BUNDLE_BACKUP=" + filepath.Join(dir, "backup"),
 	}
 
 	out, err := cmd.CombinedOutput()

--- a/targets/linux/rpm/distro/pkg.go
+++ b/targets/linux/rpm/distro/pkg.go
@@ -116,6 +116,7 @@ func (cfg *Config) InstallTestDeps(sOpt dalec.SourceOpts, targetKey string, spec
 			DnfAtRoot("/tmp/rootfs"),
 			DnfWithMounts(repoMounts),
 			DnfImportKeys(keyPaths),
+			DnfWithSourceOpts(sOpt),
 			DnfInstallWithConstraints(opts),
 		}
 

--- a/targets/linux/rpm/distro/worker.go
+++ b/targets/linux/rpm/distro/worker.go
@@ -139,6 +139,7 @@ func (cfg *Config) workerWithBuildPlatform(sOpt dalec.SourceOpts, buildPlat ocis
 	targetBase := frontend.GetBaseImage(targetSOpt, cfg.ImageRef, targetOpts...).Platform(targetPlat)
 
 	installOpts := []DnfInstallOpt{
+		DnfWithSourceOpts(sOpt),
 		DnfInstallWithConstraints(opts),
 	}
 
@@ -175,7 +176,7 @@ func (cfg *Config) workerWithBuildPlatform(sOpt dalec.SourceOpts, buildPlat ocis
 	es := buildBase.Run(
 		dalec.WithConstraints(append(opts, llb.Platform(buildPlat))...),
 		llb.AddMount(rootfsMount, targetBase),
-		cfg.InstallIntoRoot(rootfsMount, cfg.BuilderPackages, targetArch, buildPlat),
+		cfg.InstallIntoRoot(rootfsMount, cfg.BuilderPackages, targetArch, buildPlat, sOpt),
 	)
 	return es.GetMount(rootfsMount).Platform(targetPlat)
 
@@ -191,6 +192,7 @@ func (cfg *Config) SysextWorker(sOpts dalec.SourceOpts, opts ...llb.ConstraintsO
 	}
 
 	installOpts := []DnfInstallOpt{
+		DnfWithSourceOpts(sOpts),
 		DnfInstallWithConstraints(opts),
 	}
 
@@ -221,7 +223,7 @@ func (cfg *Config) SysextWorker(sOpts dalec.SourceOpts, opts ...llb.ConstraintsO
 	es := buildBase.Run(
 		dalec.WithConstraints(append(opts, llb.Platform(buildPlat))...),
 		llb.AddMount(rootfsMount, worker),
-		cfg.InstallIntoRoot(rootfsMount, []string{"erofs-utils"}, targetArch, buildPlat),
+		cfg.InstallIntoRoot(rootfsMount, []string{"erofs-utils"}, targetArch, buildPlat, sOpts),
 	)
 
 	return es.GetMount(rootfsMount).Platform(targetPlat)

--- a/test/linux_target_test.go
+++ b/test/linux_target_test.go
@@ -3746,6 +3746,18 @@ func Value() string {
 		testBuildNetworkMode(ctx, t, testConfig.Target)
 	})
 
+	t.Run("package manager proxy network", func(t *testing.T) {
+		t.Parallel()
+		ctx := startTestSpan(baseCtx, t)
+		testPackageManagerProxyNetwork(ctx, t, testConfig.Target)
+	})
+
+	t.Run("sandbox build proxy network", func(t *testing.T) {
+		t.Parallel()
+		ctx := startTestSpan(baseCtx, t)
+		testSandboxBuildProxyNetwork(ctx, t, testConfig.Target)
+	})
+
 	t.Run("user and group creation", func(t *testing.T) {
 		t.Parallel()
 		ctx := startTestSpan(baseCtx, t)

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -202,4 +202,5 @@ func testSandboxBuildProxyNetwork(ctx context.Context, t *testing.T, cfg targetC
 	if !strings.Contains(logOutput, "proxy network requests:") {
 		t.Skip("BuildKit proxy network did not activate or did not record requests in this test builder")
 	}
+	assert.Assert(t, strings.Contains(logOutput, externalTestHost), logOutput)
 }

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	moby_buildkit_v1_frontend "github.com/moby/buildkit/frontend/gateway/pb"
 	"github.com/moby/buildkit/util/stack"
 	"github.com/project-dalec/dalec"
+	"github.com/project-dalec/dalec/targets"
+	"github.com/project-dalec/dalec/test/testenv"
 	"gotest.tools/v3/assert"
 )
 
@@ -80,5 +83,123 @@ func testBuildNetworkMode(ctx context.Context, t *testing.T, cfg targetConfig) {
 				}
 			})
 		})
+	}
+}
+
+func testPackageManagerProxyNetwork(ctx context.Context, t *testing.T, cfg targetConfig) {
+	var logs strings.Builder
+	solveStatusFn := testenv.WithSolveStatusFn(func(status *testenv.SolveStatus) {
+		if status == nil {
+			return
+		}
+		for _, l := range status.Logs {
+			logs.Write(l.Data)
+		}
+	})
+
+	spec := dalec.Spec{
+		Name:        "test-package-manager-proxy-network",
+		Version:     "0.0.1",
+		Revision:    "1",
+		License:     "MIT",
+		Website:     "https://github.com/project-dalec/dalec",
+		Vendor:      "Dalec",
+		Packager:    "Dalec",
+		Description: "Should install package-manager dependencies through BuildKit proxy network",
+		Dependencies: &dalec.PackageDependencies{
+			Build: map[string]dalec.PackageConstraints{
+				cfg.GetPackage("curl"): {},
+			},
+		},
+		Build: dalec.ArtifactBuild{
+			Steps: []dalec.BuildStep{
+				{
+					Command: "touch foo",
+				},
+			},
+		},
+		Artifacts: dalec.Artifacts{
+			Binaries: map[string]dalec.ArtifactConfig{"foo": {}},
+		},
+	}
+
+	testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
+		sr := newSolveRequest(
+			withSpec(ctx, t, &spec),
+			withBuildTarget(cfg.Package),
+			withIgnoreCache(targets.IgnoreCacheKeyPkg),
+		)
+
+		_, err := gwc.Solve(ctx, sr)
+		if err != nil && strings.Contains(err.Error(), "proxy network") {
+			t.Skipf("BuildKit proxy network is not available in this test builder: %v", err)
+		}
+		assert.NilError(t, err)
+	}, testenv.WithProxyNetwork, solveStatusFn)
+
+	logOutput := logs.String()
+	if !strings.Contains(logOutput, "proxy network requests:") {
+		t.Skip("BuildKit proxy network did not activate or did not record requests in this test builder")
+	}
+}
+
+func testSandboxBuildProxyNetwork(ctx context.Context, t *testing.T, cfg targetConfig) {
+	var logs strings.Builder
+	solveStatusFn := testenv.WithSolveStatusFn(func(status *testenv.SolveStatus) {
+		if status == nil {
+			return
+		}
+		for _, l := range status.Logs {
+			logs.Write(l.Data)
+		}
+	})
+
+	spec := dalec.Spec{
+		Name:        "test-sandbox-build-proxy-network",
+		Version:     "0.0.1",
+		Revision:    "1",
+		License:     "MIT",
+		Website:     "https://github.com/project-dalec/dalec",
+		Vendor:      "Dalec",
+		Packager:    "Dalec",
+		Description: "Should capture sandbox build step HTTP(S) egress through BuildKit proxy network",
+		Dependencies: &dalec.PackageDependencies{
+			Build: map[string]dalec.PackageConstraints{
+				cfg.GetPackage("curl"): {},
+			},
+		},
+		Build: dalec.ArtifactBuild{
+			NetworkMode: "sandbox",
+			Steps: []dalec.BuildStep{
+				{
+					Command: fmt.Sprintf("curl --head -ksSf %s > /dev/null", externalTestHost),
+				},
+				{
+					Command: "touch foo",
+				},
+			},
+		},
+		Artifacts: dalec.Artifacts{
+			Binaries: map[string]dalec.ArtifactConfig{"foo": {}},
+		},
+	}
+
+	testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
+		sr := newSolveRequest(
+			withSpec(ctx, t, &spec),
+			withBuildTarget(cfg.Package),
+			withIgnoreCache(targets.IgnoreCacheKeyPkg),
+		)
+
+		_, err := gwc.Solve(ctx, sr)
+		if err != nil && strings.Contains(err.Error(), "proxy network") {
+			t.Skipf("BuildKit proxy network is not available in this test builder: %v", err)
+		}
+		assert.NilError(t, err)
+	}, testenv.WithProxyNetwork, solveStatusFn)
+
+	logOutput := logs.String()
+	if !strings.Contains(logOutput, "proxy network requests:") {
+		t.Skip("BuildKit proxy network did not activate or did not record requests in this test builder")
 	}
 }

--- a/test/testenv/buildx.go
+++ b/test/testenv/buildx.go
@@ -528,9 +528,15 @@ func (b *BuildxEnv) RunTest(ctx context.Context, t *testing.T, f TestFunc, opts 
 	defer cancelOutput()
 
 	ch := make(chan *client.SolveStatus)
-	go fowardToSolveStatusFn(ctx, ch, statusFn, cfg.SolveStatusFn)
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		fowardToSolveStatusFn(ctx, ch, statusFn, cfg.SolveStatusFn)
+	})
 
-	defer close(ch)
+	defer func() {
+		close(ch)
+		wg.Wait()
+	}()
 
 	for status, err := range b.runTestWithStatus(ctx, t, f, opts...) {
 		if err != nil {

--- a/test/testenv/buildx.go
+++ b/test/testenv/buildx.go
@@ -374,6 +374,12 @@ func WithHostNetworking(trc *TestRunnerConfig) {
 	})
 }
 
+func WithProxyNetwork(trc *TestRunnerConfig) {
+	trc.SolveOptFns = append(trc.SolveOptFns, func(so *client.SolveOpt) {
+		so.ProxyNetwork = true
+	})
+}
+
 func WithSocketProxies(proxies ...socketprovider.ProxyConfig) TestRunnerOpt {
 	return func(cfg *TestRunnerConfig) {
 		cfg.SocketProxies = append(cfg.SocketProxies, proxies...)

--- a/website/content/spec.md
+++ b/website/content/spec.md
@@ -54,6 +54,8 @@ These arguments are set based on the default docker platform for the machine, *u
 No default value should be included for these build args. These args are opt-in. If you haven't listed them in the args section as shown above, Dalec will **not** substitute values for them.
 {{< /callout >}}
 
+`DALEC_DISABLE_PROXY_CONFIG=1` can be passed as a frontend build arg to disable DALEC-managed proxy configuration for tools that need explicit proxy or CA setup. It does not need to be listed under `args`, and it does not disable BuildKit proxy networking itself.
+
 ## Metadata section
 
 Metadata section is used to define the metadata of the spec. This metadata includes the name, packager, vendor, license, website, and description of the spec.
@@ -275,6 +277,10 @@ TARGETOS is a built-in argument that Dalec will substitute with the target OS va
 {{< callout type="default" >}}
 Set `network_mode` to `sandbox` to allow internet access during build
 {{< /callout >}}
+
+:::tip
+When BuildKit proxy networking is enabled for the solve, DALEC exec steps that have network access use that proxy path. APT-based targets configure apt/aptitude from BuildKit's injected proxy environment and CA bundle, DNF/TDNF-based targets configure the package manager CA bundle while using the injected proxy environment, and npm dependency generation configures npm/Node with the injected proxy and CA bundle. Go, pip, and Cargo dependency generation use their standard proxy environment and system trust behavior. `network_mode: none` remains offline.
+:::
 
 The input of a build is a directory with all [sources](#sources-section) laid out based on their source name.
 The output of a build is the content of the input with all the provided steps executed against it.

--- a/website/content/spec.md
+++ b/website/content/spec.md
@@ -278,9 +278,9 @@ TARGETOS is a built-in argument that Dalec will substitute with the target OS va
 Set `network_mode` to `sandbox` to allow internet access during build
 {{< /callout >}}
 
-:::tip
-When BuildKit proxy networking is enabled for the solve, DALEC exec steps that have network access use that proxy path. APT-based targets configure apt/aptitude from BuildKit's injected proxy environment and CA bundle, DNF/TDNF-based targets configure the package manager CA bundle while using the injected proxy environment, and npm dependency generation configures npm/Node with the injected proxy and CA bundle. Go, pip, and Cargo dependency generation use their standard proxy environment and system trust behavior. `network_mode: none` remains offline.
-:::
+{{< callout type="info" >}}
+BuildKit proxy mode is a solve-level setting supplied by the BuildKit client or daemon. It is not a Dalec `network_mode` value and cannot be selected for only one build step. When proxy mode is enabled, network-enabled DALEC exec steps use the proxy path provided by BuildKit. APT-based targets configure apt/aptitude from the injected proxy environment and CA bundle, DNF/TDNF-based targets configure the package manager CA bundle while using the injected proxy environment, and npm dependency generation configures npm/Node with the injected proxy and CA bundle. Go, pip, and Cargo dependency generation use their standard proxy environment and system trust behavior. `network_mode: none` remains offline. Use `DALEC_DISABLE_PROXY_CONFIG=1` only when a tool must manage its own proxy or CA configuration; this disables DALEC's helper configuration, not BuildKit proxy networking.
+{{< /callout >}}
 
 The input of a build is a directory with all [sources](#sources-section) laid out based on their source name.
 The output of a build is the content of the input with all the provided steps executed against it.


### PR DESCRIPTION
Thread BuildKit build args through source options so package install helpers can detect proxy-network configuration and users can opt out with DALEC_DISABLE_PROXY_CONFIG.

Configure npm, apt, and dnf/tdnf package installs to trust the BuildKit proxy CA when proxy-network is enabled, then clean up temporary package-manager proxy config after installs.

Add focused unit coverage for the generated proxy scripts and E2E proxy-network coverage for package manager installs and sandbox build network access across Linux targets.

Fixes: #1114
