### PR TITLE
0.20.7 cherry picks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,9 +410,7 @@ jobs:
           docker buildx bake test
       - name: Build go-md2man example in docs
         run: |
-          version=$(cat docs/examples/go-md2man.yml | yq .version)
-          docker build -t go-md2man:$version -f docs/examples/go-md2man.yml --target=mariner2/rpm --output=_output .
-          docker build -t go-md2man:$version -f docs/examples/go-md2man.yml --target=mariner2 .
+          docker buildx bake examples
       - name: dump logs
         if: failure()
         id: dump-logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ on:
       - '.github/workflows/dependabot.yml'
       - '.github/workflows/release.yml'
       - '.github/workflows/deploy-docs.yml'
+      - '.github/workflows/codeql.yml'
 
   push:
     branches:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,12 +13,12 @@ name: "CodeQL"
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "release/**"]
     paths-ignore:
       - '.github/copilot-instructions.md'
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: ["main"]
+    branches: ["main", "release/**"]
     paths-ignore:
       - '.github/copilot-instructions.md'
   schedule:

--- a/packaging/linux/deb/pkg.go
+++ b/packaging/linux/deb/pkg.go
@@ -68,7 +68,11 @@ func createPatches(spec *dalec.Spec, sources map[string]llb.State, worker llb.St
 				// Remove any .git directories to prevent git from treating them as submodules.
 				// Use -prune to avoid descending into .git directories, which is more efficient
 				// and avoids errors when nested .git directories (e.g., submodules) exist.
-				dalec.ShArgs("set -e; find . -name .git -type d -prune -exec rm -rf {} +; git init .; git add .; git commit -m 'Initial commit'; \"${DEBIAN_DIR}/dalec/patch.sh\"; git add .; git commit -m 'With patch'; git diff HEAD~1 >> /work/out/dalec-changes.patch; echo 'dalec-changes.patch' > /work/out/series"),
+				// `git diff --text` emits textual hunks for files git heuristically flags as
+				// binary (e.g. generated *.pb.go, or files a source marks `-diff` in
+				// .gitattributes), which patch/dpkg-source can apply; otherwise they are
+				// dropped as "Binary files differ" and never updated.
+				dalec.ShArgs("set -e; find . -name .git -type d -prune -exec rm -rf {} +; git init .; git add --all; git commit -m 'Initial commit'; \"${DEBIAN_DIR}/dalec/patch.sh\"; git add --all; git commit -m 'With patch'; git diff --text HEAD~1 >> /work/out/dalec-changes.patch; echo 'dalec-changes.patch' > /work/out/series"),
 				llb.Dir("/work/sources"),
 				mountSources(sources, "/work/sources", nil),
 				// DEBIAN_DIR is used by the patch script to find the debian directory where we actually have the patches

--- a/targets/linux/deb/distro/pkg.go
+++ b/targets/linux/deb/distro/pkg.go
@@ -226,7 +226,7 @@ func (cfg *Config) HandleSourcePkg(ctx context.Context, client gwclient.Client) 
 		if err != nil {
 			return nil, nil, err
 		}
-		return ref, nil, nil
+		return ref, &dalec.DockerImageSpec{}, nil
 	})
 }
 

--- a/targets/linux/deb/distro/pkg.go
+++ b/targets/linux/deb/distro/pkg.go
@@ -205,6 +205,11 @@ func (cfg *Config) HandleSourcePkg(ctx context.Context, client gwclient.Client) 
 
 		worker = worker.With(cfg.InstallBuildDeps(ctx, sOpt, spec, targetKey, pg, frontend.IgnoreCache(client)))
 
+		// Preprocess after build deps are installed so generators can use build tools.
+		if err := spec.Preprocess(sOpt, worker, pg); err != nil {
+			return nil, nil, err
+		}
+
 		var cfg deb.SourcePkgConfig
 		extraPaths := prepareGo(ctx, client, &cfg, worker, spec, targetKey, pg, frontend.IgnoreCache(client))
 

--- a/test/linux_target_test.go
+++ b/test/linux_target_test.go
@@ -188,6 +188,12 @@ func testLinuxDistro(ctx context.Context, t *testing.T, testConfig testLinuxConf
 		testSourceOutputBuilds(ctx, t, testConfig.Target)
 	})
 
+	t.Run("source-output-applies-gomod-edits", func(t *testing.T) {
+		t.Parallel()
+		ctx := startTestSpan(ctx, t)
+		testSourceOutputAppliesGomodEdits(ctx, t, testConfig.Target)
+	})
+
 	t.Run("test-dalec-empty-artifacts", func(t *testing.T) {
 		t.Parallel()
 		ctx := startTestSpan(ctx, t)

--- a/test/linux_target_test.go
+++ b/test/linux_target_test.go
@@ -182,6 +182,12 @@ func testLinuxDistro(ctx context.Context, t *testing.T, testConfig testLinuxConf
 		testPrebuiltPackages(ctx, t, testConfig)
 	})
 
+	t.Run("source-output-builds", func(t *testing.T) {
+		t.Parallel()
+		ctx := startTestSpan(ctx, t)
+		testSourceOutputBuilds(ctx, t, testConfig.Target)
+	})
+
 	t.Run("test-dalec-empty-artifacts", func(t *testing.T) {
 		t.Parallel()
 		ctx := startTestSpan(ctx, t)

--- a/test/linux_target_test.go
+++ b/test/linux_target_test.go
@@ -194,6 +194,12 @@ func testLinuxDistro(ctx context.Context, t *testing.T, testConfig testLinuxConf
 		testSourceOutputAppliesGomodEdits(ctx, t, testConfig.Target)
 	})
 
+	t.Run("patch-applies-to-gitattributes-binary-file", func(t *testing.T) {
+		t.Parallel()
+		ctx := startTestSpan(ctx, t)
+		testPatchGitattributesBinaryFile(ctx, t, testConfig.Target)
+	})
+
 	t.Run("test-dalec-empty-artifacts", func(t *testing.T) {
 		t.Parallel()
 		ctx := startTestSpan(ctx, t)

--- a/test/patch_gitattributes_test.go
+++ b/test/patch_gitattributes_test.go
@@ -1,0 +1,64 @@
+package test
+
+import (
+	"context"
+	"testing"
+
+	gwclient "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/project-dalec/dalec"
+)
+
+// testPatchGitattributesBinaryFile is a regression test for the deb source
+// package flow dropping patch changes to files a source marks as non-diffable
+// (`-diff`) in .gitattributes. createPatches captures patches via `git diff`;
+// without `--text`, git emits "Binary files differ" for such files and the
+// change is lost, so the built package keeps the unpatched content. This mirrors
+// generated `*.pb.go` files (which upstreams mark `-diff`) being left stale
+// during a gomod vendor rewrite.
+func testPatchGitattributesBinaryFile(ctx context.Context, t *testing.T, targetCfg targetConfig) {
+	const patch = `--- a/marked.txt
++++ b/marked.txt
+@@ -1 +1 @@
+-OLD
++NEW
+`
+	strip := 1
+	spec := &dalec.Spec{
+		Name:        "test-dalec-gitattr-patch",
+		Version:     "0.0.1",
+		Revision:    "1",
+		License:     "MIT",
+		Description: "Regression: patches to files a source marks -diff must still apply",
+		Sources: map[string]dalec.Source{
+			"src": {
+				Inline: &dalec.SourceInline{
+					Dir: &dalec.SourceInlineDir{
+						Files: map[string]*dalec.SourceInlineFile{
+							".gitattributes": {Contents: "marked.txt -diff\n"},
+							"marked.txt":     {Contents: "OLD\n"},
+						},
+					},
+				},
+			},
+			"the-patch": {
+				Inline: &dalec.SourceInline{
+					File: &dalec.SourceInlineFile{Contents: patch},
+				},
+			},
+		},
+		Patches: map[string][]dalec.PatchSpec{
+			"src": {{Source: "the-patch", Strip: &strip}},
+		},
+		Build: dalec.ArtifactBuild{
+			Steps: []dalec.BuildStep{
+				// Fails the build if the patch to the -diff-marked file was dropped.
+				{Command: "grep -qx NEW ./src/marked.txt"},
+			},
+		},
+	}
+
+	testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
+		sr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(targetCfg.Package))
+		solveT(ctx, t, gwc, sr)
+	})
+}

--- a/test/source_package_test.go
+++ b/test/source_package_test.go
@@ -1,0 +1,57 @@
+package test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	gwclient "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/project-dalec/dalec"
+)
+
+// testSourceOutputBuilds is a regression test for a nil image-config panic in
+// the "output-only" targets that emit the package source form (deb "/dsc",
+// rpm "/rpm/debug/sources"). The deb handler returned a nil image config, which
+// buildkit dereferenced when assembling the export platform. Building the
+// target is enough to exercise that path across distros.
+func testSourceOutputBuilds(ctx context.Context, t *testing.T, targetCfg targetConfig) {
+	var sourceTarget string
+	switch {
+	case strings.HasSuffix(targetCfg.Package, "/deb"):
+		sourceTarget = strings.TrimSuffix(targetCfg.Package, "/deb") + "/dsc"
+	case strings.HasSuffix(targetCfg.Package, "/rpm"):
+		sourceTarget = targetCfg.Package + "/debug/sources"
+	default:
+		t.Skipf("no source-output target known for package target %q", targetCfg.Package)
+	}
+
+	spec := &dalec.Spec{
+		Name:        "test-dalec-source-output",
+		Version:     "0.0.1",
+		Revision:    "1",
+		Description: "Testing source output target builds",
+		License:     "MIT",
+		Sources: map[string]dalec.Source{
+			"src": {
+				Inline: &dalec.SourceInline{
+					File: &dalec.SourceInlineFile{Contents: "hello world"},
+				},
+			},
+		},
+		Artifacts: dalec.Artifacts{
+			Binaries: map[string]dalec.ArtifactConfig{
+				"src": {},
+			},
+		},
+		Build: dalec.ArtifactBuild{
+			Steps: []dalec.BuildStep{
+				{Command: "true"},
+			},
+		},
+	}
+
+	testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
+		sr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(sourceTarget))
+		solveT(ctx, t, gwc, sr)
+	})
+}

--- a/test/source_package_test.go
+++ b/test/source_package_test.go
@@ -5,8 +5,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/moby/buildkit/client/llb"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/project-dalec/dalec"
+	"gotest.tools/v3/assert"
 )
 
 // testSourceOutputBuilds is a regression test for a nil image-config panic in
@@ -53,5 +55,77 @@ func testSourceOutputBuilds(ctx context.Context, t *testing.T, targetCfg targetC
 	testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
 		sr := newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(sourceTarget))
 		solveT(ctx, t, gwc, sr)
+	})
+}
+
+// testSourceOutputAppliesGomodEdits verifies that spec preprocessing (gomod
+// replace directives) is applied when producing the deb source package output.
+// The handler previously skipped Preprocess, silently emitting a source package
+// missing the generated gomod patch.
+func testSourceOutputAppliesGomodEdits(ctx context.Context, t *testing.T, targetCfg targetConfig) {
+	if !strings.HasSuffix(targetCfg.Package, "/deb") {
+		t.Skip("source-package preprocessing check only implemented for deb /dsc")
+	}
+	sourceTarget := strings.TrimSuffix(targetCfg.Package, "/deb") + "/dsc"
+
+	spec := &dalec.Spec{
+		Name:        "test-dalec-dsc-preprocess",
+		Version:     "0.0.1",
+		Revision:    "1",
+		License:     "MIT",
+		Description: "gomod edits must be preprocessed into the source package",
+		Sources: map[string]dalec.Source{
+			"src": {
+				Generate: []*dalec.SourceGenerator{
+					{
+						Gomod: &dalec.GeneratorGomod{
+							Edits: &dalec.GomodEdits{
+								Replace: []dalec.GomodReplace{
+									{Original: "github.com/cpuguy83/tar2go@v0.3.1", Update: "github.com/cpuguy83/tar2go@v0.3.0"},
+								},
+							},
+						},
+					},
+				},
+				Inline: &dalec.SourceInline{
+					Dir: &dalec.SourceInlineDir{
+						Files: map[string]*dalec.SourceInlineFile{
+							"main.go": {Contents: gomodFixtureMain},
+							// go 1.18 so `go mod tidy` (run by Preprocess) works on
+							// distros shipping older Go toolchains (e.g. Jammy's 1.18).
+							"go.mod": {Contents: "module testgomodsource\n\ngo 1.18\n\nrequire github.com/cpuguy83/tar2go v0.3.1\n"},
+							"go.sum": {Contents: gomodFixtureSum},
+						},
+					},
+				},
+			},
+		},
+		Dependencies: &dalec.PackageDependencies{
+			Build: map[string]dalec.PackageConstraints{
+				targetCfg.GetPackage("golang"): {},
+			},
+		},
+	}
+
+	testEnv.RunTest(ctx, t, func(ctx context.Context, gwc gwclient.Client) {
+		res := solveT(ctx, t, gwc, newSolveRequest(withSpec(ctx, t, spec), withBuildTarget(sourceTarget)))
+
+		// Pull dalec-changes.patch out of the source package and confirm the
+		// gomod replace directive made it in (i.e. Preprocess ran).
+		st := llb.Image("alpine:latest").
+			Run(dalec.ShArgs("apk add --no-cache tar xz")).Root().
+			Run(
+				dalec.ShArgs(`set -e; mkdir -p /out /x; for f in /src/*.debian.tar.xz; do tar -xJf "$f" -C /x; done; cp /x/debian/patches/dalec-changes.patch /out/patch`),
+				llb.AddMount("/src", resultToState(t, res), llb.Readonly),
+			).AddMount("/out", llb.Scratch())
+
+		def, err := st.Marshal(ctx)
+		assert.NilError(t, err)
+		out, err := gwc.Solve(ctx, gwclient.SolveRequest{Definition: def.ToPB(), Evaluate: true})
+		assert.NilError(t, err)
+
+		patch := string(readFile(ctx, t, "patch", out))
+		assert.Check(t, strings.Contains(patch, "replace github.com/cpuguy83/tar2go"),
+			"source package patch must contain the gomod replace directive (Preprocess must run for source packages), got:\n%s", patch)
 	})
 }


### PR DESCRIPTION
Backports the DEB source-package fixes from #1179:

- Avoid nil image config panic.
- Preprocess source DEB specs.
- Preserve files Git classifies as binary (including generated `.pb.go` files) in generated patches.

Validation:
- `go test --test.short --timeout=10m ./...`
- `go run ./cmd/lint ./...`
- `go generate ./...` with no diff.