### PR TITLE
ci: Run codeql on release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ on:
       - '.github/workflows/dependabot.yml'
       - '.github/workflows/release.yml'
       - '.github/workflows/deploy-docs.yml'
+      - '.github/workflows/codeql.yml'
 
   push:
     branches:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,12 +13,12 @@ name: "CodeQL"
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "release/**"]
     paths-ignore:
       - '.github/copilot-instructions.md'
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: ["main"]
+    branches: ["main", "release/**"]
     paths-ignore:
       - '.github/copilot-instructions.md'
   schedule:


### PR DESCRIPTION
This is required per rulesets.
