### PR TITLE
Make proxy script tests portable

### DIFF
--- a/generator_nodemodules_test.go
+++ b/generator_nodemodules_test.go
@@ -2,6 +2,7 @@ package dalec
 
 import (
 	"context"
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -86,7 +87,7 @@ configure_npm_proxy
 	"${NODE_EXTRA_CA_CERTS:-}"
 `)
 	cmd.Env = []string{
-		"PATH=/bin:/usr/bin",
+		"PATH=" + os.Getenv("PATH"),
 		"HTTP_PROXY=http://proxy.example:3128",
 		"HTTPS_PROXY=https://proxy.example:8443",
 		"NO_PROXY=localhost,127.0.0.1",
@@ -110,7 +111,7 @@ func TestConfigureNpmProxyDoesNotTraceProxyValues(t *testing.T) {
 
 	cmd := exec.Command("/bin/sh", "-c", "set -x\n"+npmProxyConfigScript+"\nconfigure_npm_proxy\n")
 	cmd.Env = []string{
-		"PATH=/bin:/usr/bin",
+		"PATH=" + os.Getenv("PATH"),
 		"HTTP_PROXY=http://user:secret@proxy.example:3128",
 	}
 
@@ -134,7 +135,7 @@ configure_npm_proxy
 	"${NODE_EXTRA_CA_CERTS:-}"
 `)
 	cmd.Env = []string{
-		"PATH=/bin:/usr/bin",
+		"PATH=" + os.Getenv("PATH"),
 		"HTTP_PROXY=http://proxy.example:3128",
 		"HTTPS_PROXY=https://proxy.example:8443",
 		"DALEC_DISABLE_PROXY_CONFIG=1",

--- a/targets/linux/deb/distro/install_test.go
+++ b/targets/linux/deb/distro/install_test.go
@@ -19,7 +19,7 @@ func TestConfigureAptProxyWritesConfig(t *testing.T) {
 	conf := filepath.Join(t.TempDir(), "apt.conf")
 	cmd := exec.Command("/bin/sh", "-c", aptProxyConfigScript+"\nconfigure_apt_proxy\nprintf '%s' \"${APT_CONFIG}\"\n")
 	cmd.Env = []string{
-		"PATH=/bin:/usr/bin",
+		"PATH=" + os.Getenv("PATH"),
 		"HTTP_PROXY=http://proxy.example:3128",
 		"HTTPS_PROXY=https://proxy.example:8443",
 		"DALEC_APT_PROXY_CONFIG=" + conf,
@@ -49,7 +49,7 @@ func TestConfigureAptProxyDoesNotTraceProxyValues(t *testing.T) {
 	conf := filepath.Join(t.TempDir(), "apt.conf")
 	cmd := exec.Command("/bin/sh", "-c", "set -x\n"+aptProxyConfigScript+"\nconfigure_apt_proxy\n")
 	cmd.Env = []string{
-		"PATH=/bin:/usr/bin",
+		"PATH=" + os.Getenv("PATH"),
 		"HTTP_PROXY=http://user:secret@proxy.example:3128",
 		"DALEC_APT_PROXY_CONFIG=" + conf,
 	}
@@ -67,7 +67,7 @@ func TestCleanupAptProxyRemovesConfig(t *testing.T) {
 	conf := filepath.Join(t.TempDir(), "apt.conf")
 	cmd := exec.Command("/bin/sh", "-c", aptProxyConfigScript+"\nconfigure_apt_proxy\ncleanup_apt_proxy\nif [ -n \"${APT_CONFIG:-}\" ] || [ -e \"${DALEC_APT_PROXY_CONFIG}\" ]; then exit 1; fi\n")
 	cmd.Env = []string{
-		"PATH=/bin:/usr/bin",
+		"PATH=" + os.Getenv("PATH"),
 		"HTTP_PROXY=http://proxy.example:3128",
 		"DALEC_APT_PROXY_CONFIG=" + conf,
 	}
@@ -86,7 +86,7 @@ func TestCleanupAptProxyRestoresAptConfig(t *testing.T) {
 	original := filepath.Join(dir, "original.conf")
 	cmd := exec.Command("/bin/sh", "-c", aptProxyConfigScript+"\nconfigure_apt_proxy\ncleanup_apt_proxy\nprintf '%s' \"${APT_CONFIG:-}\"\n")
 	cmd.Env = []string{
-		"PATH=/bin:/usr/bin",
+		"PATH=" + os.Getenv("PATH"),
 		"APT_CONFIG=" + original,
 		"HTTP_PROXY=http://proxy.example:3128",
 		"DALEC_APT_PROXY_CONFIG=" + conf,
@@ -105,7 +105,7 @@ func TestConfigureAptProxyDisabled(t *testing.T) {
 	conf := filepath.Join(t.TempDir(), "apt.conf")
 	cmd := exec.Command("/bin/sh", "-c", aptProxyConfigScript+"\nconfigure_apt_proxy\nif [ -n \"${APT_CONFIG:-}\" ] || [ -e \"${DALEC_APT_PROXY_CONFIG}\" ]; then exit 1; fi\n")
 	cmd.Env = []string{
-		"PATH=/bin:/usr/bin",
+		"PATH=" + os.Getenv("PATH"),
 		"HTTP_PROXY=http://proxy.example:3128",
 		"DALEC_APT_PROXY_CONFIG=" + conf,
 		"DALEC_DISABLE_PROXY_CONFIG=1",

--- a/targets/linux/rpm/distro/dnf_install_test.go
+++ b/targets/linux/rpm/distro/dnf_install_test.go
@@ -20,13 +20,13 @@ func TestConfigureDnfProxyAddsCACertOptions(t *testing.T) {
 	err := os.WriteFile(caBundle, []byte("test ca"), 0o600)
 	assert.NilError(t, err)
 
-	cmd := exec.Command("/bin/bash", "-c", dnfProxyConfigScript+`
+	cmd := exec.Command("bash", "-c", dnfProxyConfigScript+`
 install_flags="-y"
 configure_dnf_proxy
 printf '%s\n%s\n%s\n' "${install_flags}" "${SSL_CERT_FILE:-}" "${CURL_CA_BUNDLE:-}"
 `)
 	cmd.Env = []string{
-		"PATH=/bin:/usr/bin",
+		"PATH=" + os.Getenv("PATH"),
 		"HTTPS_PROXY=http://proxy.example:3128",
 		"DALEC_RPM_PROXY_CA_BUNDLE=" + caBundle,
 	}
@@ -51,12 +51,12 @@ func TestConfigureDnfProxyDoesNotTraceProxyValues(t *testing.T) {
 	err := os.WriteFile(caBundle, []byte("test ca"), 0o600)
 	assert.NilError(t, err)
 
-	cmd := exec.Command("/bin/bash", "-c", "set -x\n"+dnfProxyConfigScript+`
+	cmd := exec.Command("bash", "-c", "set -x\n"+dnfProxyConfigScript+`
 install_flags="-y"
 configure_dnf_proxy
 `)
 	cmd.Env = []string{
-		"PATH=/bin:/usr/bin",
+		"PATH=" + os.Getenv("PATH"),
 		"HTTP_PROXY=http://user:secret@proxy.example:3128",
 		"DALEC_RPM_PROXY_CA_BUNDLE=" + caBundle,
 	}
@@ -83,7 +83,7 @@ proxy ca
 	err = os.WriteFile(trustBundle, []byte("trust ca\n"), 0o600)
 	assert.NilError(t, err)
 
-	cmd := exec.Command("/bin/bash", "-c", dnfProxyConfigScript+`
+	cmd := exec.Command("bash", "-c", dnfProxyConfigScript+`
 install_flags="-y"
 configure_dnf_proxy
 grep -q 'buildkit proxy CA begin' "${DALEC_RPM_PROXY_TRUST_BUNDLE}"
@@ -93,7 +93,7 @@ if grep -q 'buildkit proxy CA begin' "${DALEC_RPM_PROXY_TRUST_BUNDLE}"; then exi
 grep -q 'new ca' "${DALEC_RPM_PROXY_TRUST_BUNDLE}"
 `)
 	cmd.Env = []string{
-		"PATH=/bin:/usr/bin",
+		"PATH=" + os.Getenv("PATH"),
 		"HTTP_PROXY=http://proxy.example:3128",
 		"DALEC_RPM_PROXY_CA_BUNDLE=" + caBundle,
 		"DALEC_RPM_PROXY_TRUST_BUNDLE=" + trustBundle,
@@ -112,14 +112,14 @@ func TestConfigureDnfProxyDisabled(t *testing.T) {
 	err := os.WriteFile(caBundle, []byte("test ca"), 0o600)
 	assert.NilError(t, err)
 
-	cmd := exec.Command("/bin/bash", "-c", dnfProxyConfigScript+`
+	cmd := exec.Command("bash", "-c", dnfProxyConfigScript+`
 install_flags="-y"
 configure_dnf_proxy
 if [ "${install_flags}" != "-y" ]; then exit 1; fi
 if [ -n "${SSL_CERT_FILE:-}" ] || [ -n "${CURL_CA_BUNDLE:-}" ]; then exit 1; fi
 `)
 	cmd.Env = []string{
-		"PATH=/bin:/usr/bin",
+		"PATH=" + os.Getenv("PATH"),
 		"HTTP_PROXY=http://proxy.example:3128",
 		"DALEC_RPM_PROXY_CA_BUNDLE=" + caBundle,
 		"DALEC_DISABLE_PROXY_CONFIG=1",

--- a/targets/linux/rpm/distro/zypper_install_test.go
+++ b/targets/linux/rpm/distro/zypper_install_test.go
@@ -42,7 +42,7 @@ proxy ca
 	err = os.WriteFile(updateCA, []byte("#!/bin/sh\nprintf 'updated\\n' >> \"$DALEC_ZYPPER_UPDATE_LOG\"\n"), 0o700)
 	assert.NilError(t, err)
 
-	cmd := exec.Command("/bin/bash", "-c", zypperProxyConfigScript+`
+	cmd := exec.Command("bash", "-c", zypperProxyConfigScript+`
 configure_zypper_proxy
 grep -q 'buildkit proxy CA begin' "${DALEC_ZYPPER_PROXY_ANCHOR}"
 cleanup_zypper_proxy
@@ -50,7 +50,7 @@ if [ -e "${DALEC_ZYPPER_PROXY_ANCHOR}" ]; then exit 1; fi
 if [ "$(wc -l < "${DALEC_ZYPPER_UPDATE_LOG}")" -ne 2 ]; then exit 1; fi
 `)
 	cmd.Env = []string{
-		"PATH=/bin:/usr/bin",
+		"PATH=" + os.Getenv("PATH"),
 		"HTTPS_PROXY=http://proxy.example:3128",
 		"DALEC_RPM_PROXY_CA_BUNDLE=" + sourceBundle,
 		"DALEC_ZYPPER_PROXY_ANCHOR=" + proxyAnchor,
@@ -72,11 +72,11 @@ func TestConfigureZypperProxyDoesNotTraceProxyValues(t *testing.T) {
 	assert.NilError(t, err)
 
 	const proxyURL = "http://dalec-proxy-value-sentinel@proxy.example:3128"
-	cmd := exec.Command("/bin/bash", "-c", "set -x\n"+zypperProxyConfigScript+`
+	cmd := exec.Command("bash", "-c", "set -x\n"+zypperProxyConfigScript+`
 configure_zypper_proxy
 `)
 	cmd.Env = []string{
-		"PATH=/bin:/usr/bin",
+		"PATH=" + os.Getenv("PATH"),
 		"HTTP_PROXY=" + proxyURL,
 		"DALEC_RPM_PROXY_CA_BUNDLE=" + caBundle,
 	}
@@ -95,12 +95,12 @@ func TestConfigureZypperProxyDisabled(t *testing.T) {
 	err := os.WriteFile(caBundle, []byte("test ca"), 0o600)
 	assert.NilError(t, err)
 
-	cmd := exec.Command("/bin/bash", "-c", zypperProxyConfigScript+`
+	cmd := exec.Command("bash", "-c", zypperProxyConfigScript+`
 configure_zypper_proxy
 if [ -e "${DALEC_ZYPPER_PROXY_ANCHOR}" ]; then exit 1; fi
 `)
 	cmd.Env = []string{
-		"PATH=/bin:/usr/bin",
+		"PATH=" + os.Getenv("PATH"),
 		"HTTP_PROXY=http://proxy.example:3128",
 		"DALEC_RPM_PROXY_CA_BUNDLE=" + caBundle,
 		"DALEC_ZYPPER_PROXY_ANCHOR=" + filepath.Join(t.TempDir(), "proxy.pem"),


### PR DESCRIPTION
Proxy config tests hardcoded child PATH=/bin:/usr/bin and invoked bash via /bin/bash. Ubuntu-based CI happened to have those tools at those paths, but the tests failed on NixOS and other distros where core utilities live elsewhere.

This changes the child process PATH to inherit the test runner's PATH and resolves bash via PATH instead of assuming /bin/bash. /bin/sh is left unchanged since it's a stable, portable path. Proxy env var isolation (the child process only gets an explicit env list) is preserved.

Testing:
- `go test --test.short --timeout=10m ./...`
- `go run ./cmd/lint ./...`