### PR TITLE
gomod: exclude go module proxy zip cache from generated source deps

### DIFF
--- a/generator_gomod.go
+++ b/generator_gomod.go
@@ -6,6 +6,7 @@ import (
 	goerrors "errors"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/goccy/go-yaml/ast"
@@ -282,7 +283,40 @@ func (s *Spec) GomodDeps(sOpt SourceOpts, worker llb.State, opts ...llb.Constrai
 		})
 	}
 
-	deps = deps.With(sourceFilter(sOpt, opts...))
+	deps = deps.With(func(in llb.State) llb.State {
+		// gomodZipCacheExclude matches the module zip archives the go
+		// command keeps under $GOMODCACHE/cache/download, rooted at the go
+		// module cache (gomodCacheDir). "go mod download" always extracts a
+		// module's contents directly under $GOMODCACHE/<module>@<version> in
+		// addition to keeping this zip copy around, so the extracted
+		// sources are already present elsewhere in the cache. Excluding the
+		// zip avoids duplicating that content (e.g. in generated source
+		// packages) while keeping the extracted sources and the small
+		// .mod/.info/.ziphash metadata files intact.
+		const gomodZipCacheExclude = "cache/download/**/*.zip"
+
+		excludes, err := sOpt.sourceFilterExcludes()
+		if err != nil {
+			return ErrorState(in, err)
+		}
+		// Always filter out the go module proxy's cached zip archives,
+		// regardless of any build-time source filter config, since they
+		// only duplicate content already extracted into the module cache.
+		//
+		// The mandatory pattern is appended last (rather than first) because
+		// exclude patterns are matched in order with support for "!"
+		// negation (like a .dockerignore file): a later pattern can
+		// re-include a path an earlier pattern excluded. Putting it last
+		// ensures a configured source filter cannot inadvertently negate it.
+		//
+		// excludes is cloned before appending because sOpt.SourceFilter is
+		// memoized (e.g. via sync.OnceValues in the frontend), so this same
+		// backing slice can be shared and read concurrently by other
+		// generators/build targets using the same SourceOpts; appending to
+		// it directly could race on or corrupt that shared slice.
+		all := append(slices.Clone(excludes), gomodZipCacheExclude)
+		return in.With(SourceFilter(SourceFilterConfig{GlobalExcludes: all}, opts...))
+	})
 	return &deps
 }
 

--- a/generator_gomod_test.go
+++ b/generator_gomod_test.go
@@ -3,12 +3,14 @@ package dalec
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"slices"
 	"strings"
 	"testing"
 
 	"github.com/goccy/go-yaml"
 	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/patternmatcher"
 )
 
 func TestGomodReplaceUnmarshal(t *testing.T) {
@@ -301,6 +303,99 @@ func TestGomodEditArgs_DropRequire(t *testing.T) {
 	}
 }
 
+func TestGomodDepsExcludesModuleZipCache(t *testing.T) {
+	t.Parallel()
+
+	t.Run("with no configured source filter, the zip cache is still excluded", func(t *testing.T) {
+		t.Parallel()
+
+		spec := testGomodProxySpec()
+		st := spec.GomodDeps(testGomodProxySourceOpts(""), llb.Scratch())
+		if st == nil {
+			t.Fatal("gomod generator succeeded but returned nil state")
+		}
+
+		excludes := gomodDepsCopyExcludes(context.Background(), t, *st)
+		if !slices.Contains(excludes, "cache/download/**/*.zip") {
+			t.Fatalf("expected gomod deps to exclude module zip cache, got %v", excludes)
+		}
+	})
+
+	t.Run("with a configured source filter, both the zip cache and the configured excludes apply", func(t *testing.T) {
+		t.Parallel()
+
+		spec := testGomodProxySpec()
+		sOpt := testGomodProxySourceOpts("")
+		sOpt.SourceFilter = func() (SourceFilterConfig, error) {
+			return SourceFilterConfig{GlobalExcludes: []string{"**/testdata/**"}}, nil
+		}
+
+		st := spec.GomodDeps(sOpt, llb.Scratch())
+		if st == nil {
+			t.Fatal("gomod generator succeeded but returned nil state")
+		}
+
+		excludes := gomodDepsCopyExcludes(context.Background(), t, *st)
+		if !slices.Contains(excludes, "cache/download/**/*.zip") {
+			t.Fatalf("expected gomod deps to still exclude module zip cache, got %v", excludes)
+		}
+		if !slices.Contains(excludes, "**/testdata/**") {
+			t.Fatalf("expected gomod deps to include configured excludes, got %v", excludes)
+		}
+	})
+
+	t.Run("a failing source filter is surfaced as an error state", func(t *testing.T) {
+		t.Parallel()
+
+		spec := testGomodProxySpec()
+		sOpt := testGomodProxySourceOpts("")
+		sOpt.SourceFilter = func() (SourceFilterConfig, error) {
+			return SourceFilterConfig{}, errors.New("boom")
+		}
+
+		st := spec.GomodDeps(sOpt, llb.Scratch())
+		if st == nil {
+			t.Fatal("gomod generator succeeded but returned nil state")
+		}
+
+		_, err := st.Marshal(context.Background())
+		if err == nil || !strings.Contains(err.Error(), "boom") {
+			t.Fatalf("expected marshal to surface source filter error, got %v", err)
+		}
+	})
+
+	t.Run("a configured source filter cannot re-include the zip cache via negation", func(t *testing.T) {
+		t.Parallel()
+
+		// Exclude patterns are matched in order with support for "!"
+		// negation (like a .dockerignore file). If a downstream config
+		// negated the zip pattern and that negation were applied after the
+		// mandatory exclude, it would re-include the zip cache. The
+		// mandatory pattern must be the effective, final word.
+		spec := testGomodProxySpec()
+		sOpt := testGomodProxySourceOpts("")
+		sOpt.SourceFilter = func() (SourceFilterConfig, error) {
+			return SourceFilterConfig{GlobalExcludes: []string{"!cache/download/**/*.zip"}}, nil
+		}
+
+		st := spec.GomodDeps(sOpt, llb.Scratch())
+		if st == nil {
+			t.Fatal("gomod generator succeeded but returned nil state")
+		}
+
+		excludes := gomodDepsCopyExcludes(context.Background(), t, *st)
+
+		const zipPath = "cache/download/github.com/pkg/errors/@v/v0.9.1.zip"
+		matched, err := patternmatcher.Matches(zipPath, excludes)
+		if err != nil {
+			t.Fatalf("failed to evaluate exclude patterns: %v", err)
+		}
+		if !matched {
+			t.Fatalf("expected zip cache path %q to still be excluded despite a negated configured pattern, got excludes %v", zipPath, excludes)
+		}
+	})
+}
+
 func TestGomodDepsUsesGomodProxy(t *testing.T) {
 	t.Parallel()
 
@@ -453,5 +548,32 @@ func gomodPatchExecEnv(ctx context.Context, t *testing.T, st llb.State) []string
 	}
 
 	t.Fatal("expected gomod patch exec")
+	return nil
+}
+
+// gomodDepsCopyExcludes returns the ExcludePatterns of the final source-filter
+// copy applied by [Spec.GomodDeps]. That copy is identified as the one whose
+// destination is the state root ("/") and whose CopyDirContentsOnly is set,
+// matching what [SourceFilter] produces.
+func gomodDepsCopyExcludes(ctx context.Context, t *testing.T, st llb.State) []string {
+	t.Helper()
+
+	for _, op := range sourceOpsFromState(ctx, t, st) {
+		fileOp := op.GetFile()
+		if fileOp == nil {
+			continue
+		}
+		for _, action := range fileOp.Actions {
+			cp := action.GetCopy()
+			if cp == nil {
+				continue
+			}
+			if cp.Dest == "/" && cp.DirCopyContents {
+				return cp.ExcludePatterns
+			}
+		}
+	}
+
+	t.Fatal("expected gomod deps source-filter copy")
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/moby/buildkit v0.31.2
 	github.com/moby/docker-image-spec v1.3.1
 	github.com/moby/go-archive v0.2.1
+	github.com/moby/patternmatcher v0.6.1
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
@@ -71,7 +72,6 @@ require (
 	github.com/klauspost/compress v1.18.7 // indirect
 	github.com/mailru/easyjson v0.9.1 // indirect
 	github.com/moby/locker v1.0.1 // indirect
-	github.com/moby/patternmatcher v0.6.1 // indirect
 	github.com/moby/sys/signal v0.7.1 // indirect
 	github.com/morikuni/aec v1.1.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.3.1 // indirect

--- a/test/source_test.go
+++ b/test/source_test.go
@@ -1211,6 +1211,109 @@ global_excludes:
 	})
 }
 
+// TestGomodDepsExcludesZipCache is an integration-level regression test for
+// GomodDeps' built-in zip-cache exclusion. It runs a real `go mod download`
+// through the "debug/gomods" target and inspects the resulting filesystem,
+// rather than only unit-testing the LLB the generator constructs.
+func TestGomodDepsExcludesZipCache(t *testing.T) {
+	t.Parallel()
+
+	const (
+		module    = "github.com/cpuguy83/tar2go"
+		version   = "v0.3.1"
+		moduleDir = module + "@" + version
+		// Real on-disk layout of the go module cache for this module/version,
+		// as populated by `go mod download` under $GOMODCACHE.
+		zipPath  = "cache/download/" + module + "/@v/" + version + ".zip"
+		modPath  = "cache/download/" + module + "/@v/" + version + ".mod"
+		infoPath = "cache/download/" + module + "/@v/" + version + ".info"
+	)
+
+	newSpec := func() *dalec.Spec {
+		return &dalec.Spec{
+			Name:        "test-gomod-zip-cache-excludes",
+			Version:     "0.0.1",
+			Revision:    "1",
+			License:     "MIT",
+			Website:     "https://github.com/project-dalec/dalec",
+			Vendor:      "Dalec",
+			Packager:    "Dalec",
+			Description: "Testing that GomodDeps excludes the go module zip cache",
+			Sources: map[string]dalec.Source{
+				"src": {
+					Generate: []*dalec.SourceGenerator{{Gomod: &dalec.GeneratorGomod{}}},
+					Inline: &dalec.SourceInline{
+						Dir: &dalec.SourceInlineDir{
+							Files: map[string]*dalec.SourceInlineFile{
+								"main.go": {Contents: gomodFixtureMain},
+								"go.mod":  {Contents: gomodFixtureMod},
+								"go.sum":  {Contents: gomodFixtureSum},
+							},
+						},
+					},
+				},
+			},
+			Dependencies: &dalec.PackageDependencies{
+				Build: map[string]dalec.PackageConstraints{
+					"golang": {},
+				},
+			},
+		}
+	}
+
+	t.Run("when no source filter is configured, the module zip is excluded but the extracted module and its metadata remain", func(t *testing.T) {
+		t.Parallel()
+
+		runTest(t, func(ctx context.Context, gwc gwclient.Client) {
+			req := newSolveRequest(withBuildTarget("debug/gomods"), withSpec(ctx, t, newSpec()))
+			res := solveT(ctx, t, gwc, req)
+			ref, err := res.SingleRef()
+			assert.NilError(t, err)
+
+			_, err = ref.StatFile(ctx, gwclient.StatRequest{Path: zipPath})
+			assert.Assert(t, err != nil, "expected module zip cache file %q to be excluded from GomodDeps output", zipPath)
+
+			stat, err := ref.StatFile(ctx, gwclient.StatRequest{Path: moduleDir})
+			assert.NilError(t, err, "extracted module sources must still be present")
+			assert.Assert(t, fs.FileMode(stat.Mode).IsDir())
+
+			_, err = ref.StatFile(ctx, gwclient.StatRequest{Path: modPath})
+			assert.NilError(t, err, "go.mod cache metadata must be retained")
+
+			_, err = ref.StatFile(ctx, gwclient.StatRequest{Path: infoPath})
+			assert.NilError(t, err, "module info cache metadata must be retained")
+		})
+	})
+
+	t.Run("when a downstream source filter negates the zip exclude, the zip remains excluded", func(t *testing.T) {
+		t.Parallel()
+
+		// This directly exercises the pattern-ordering fix: a downstream
+		// config that (accidentally or otherwise) tries to re-include the
+		// zip cache via a "!" negated pattern must not be able to override
+		// the generator's mandatory exclude.
+		filterConfig := llb.Scratch().File(llb.Mkfile("/source-filter.yml", 0o644, []byte(`
+global_excludes:
+  - "!cache/download/**/*.zip"
+`)))
+
+		runTest(t, func(ctx context.Context, gwc gwclient.Client) {
+			req := newSolveRequest(
+				withBuildTarget("debug/gomods"),
+				withSpec(ctx, t, newSpec()),
+				withBuildContext(ctx, t, dalec.DefaultSourceOptionsContextName, filterConfig),
+				withBuildArg(dalec.BuildArgDalecSourceFilterConfigPath, "/source-filter.yml"),
+			)
+			res := solveT(ctx, t, gwc, req)
+			ref, err := res.SingleRef()
+			assert.NilError(t, err)
+
+			_, err = ref.StatFile(ctx, gwclient.StatRequest{Path: zipPath})
+			assert.Assert(t, err != nil, "a downstream negated pattern must not be able to re-include the module zip cache")
+		})
+	})
+}
+
 func TestDebugSourcesSourceFilterConfig(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`go mod download` extracts each module's contents directly under `$GOMODCACHE/<module>@<version>` in addition to keeping a redundant zip copy under `$GOMODCACHE/cache/download/**/@v/*.zip`. `GomodDeps` was packaging both into generated RPM/DEB source packages, needlessly bloating them with a duplicate copy of every module's sources.

`GomodDeps` now always excludes that zip cache using the existing `SourceFilter` mechanism, merging the mandatory exclude with (and after) any downstream build-time source filter config. The exclude is appended last rather than first because exclude patterns are matched in order with `.dockerignore`-style `!` negation support: putting it last ensures a downstream-configured filter can't accidentally (or intentionally) re-include the zip cache via a leading `!` pattern.

The extracted module sources and the small `.mod`/`.info`/`.ziphash` cache metadata files are left untouched; only the bulky `.zip` archives are dropped. Other generators (cargohome, pip, nodemodules) are unaffected.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
- Added unit tests (`generator_gomod_test.go`) that inspect the generated LLB directly, including a regression test proving a downstream `"!cache/download/**/*.zip"` filter can't re-include the excluded zip.
- Added an integration test (`test/source_test.go`) that runs a real build through the `debug/gomods` target and checks the actual output filesystem, covering both the default-exclude case and the negation-resistance case end-to-end.
- `go.mod`: `github.com/moby/patternmatcher` promoted from indirect to direct (used by the new negation regression unit test to validate real pattern-matching semantics).