### PR TITLE
ci: disable buildkit gc for cache tests

### DIFF
--- a/.github/buildkitd-ci.toml
+++ b/.github/buildkitd-ci.toml
@@ -1,0 +1,8 @@
+# Persistent cache mounts are best-effort and may be pruned by BuildKit GC
+# between solves. CI cache-contract tests intentionally validate persistence
+# and sharing behavior, so keep cache-mount records for the duration of the job.
+[worker.oci]
+  gc = false
+
+[worker.containerd]
+  gc = false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,11 +240,10 @@ jobs:
           # Disable buildkit GC. It has been evicting persistent caches
           # mid-build and causing flakes; freeing up runner disk earlier in the
           # job makes keeping the cache around for the whole run feasible.
-          printf '[worker.oci]\n  gc = false\n' > /tmp/buildkitd.toml
           docker buildx create --use \
             --driver-opt network=host \
             --driver-opt image=${BUILDKIT_TEST_IMAGE} \
-            --buildkitd-config /tmp/buildkitd.toml
+            --buildkitd-config .github/buildkitd-ci.toml
       - name: Pre-build base images
         run: |
           set -eu
@@ -458,9 +457,13 @@ jobs:
           # Use a buildx container builder pinned to the buildkit version under
           # test so both diff/merge matrix legs exercise the same buildkitd
           # rather than diff/merge=1 falling back to the engine's embedded buildkit.
+          #
+          # Use the same GC-disabled config as the integration tests because
+          # persistent cache mounts are best-effort and can be pruned between solves.
           docker buildx create --use \
             --driver-opt network=host \
-            --driver-opt image=${BUILDKIT_TEST_IMAGE}
+            --driver-opt image=${BUILDKIT_TEST_IMAGE} \
+            --buildkitd-config .github/buildkitd-ci.toml
           echo USE_BUILDX=1 >> $GITHUB_ENV
 
           if [ "${DALEC_DISABLE_DIFF_MERGE}" = "0" ]; then


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a shared BuildKit configuration that disables worker GC.

BuildKit GC can remove persistent cache mounts between solves. This can make cache integration tests 
fail intermittently.
The integration and E2E builders now use the same GC-disabled configuration.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #1121
