### PR TITLE
fix(sles): bootstrap base packages separately

### DIFF
--- a/targets/linux/rpm/distro/container.go
+++ b/targets/linux/rpm/distro/container.go
@@ -50,8 +50,9 @@ func (cfg *Config) BuildContainer(ctx context.Context, client gwclient.Client, s
 	pkgs := []string{
 		filepath.Join(rpmMountDir, "**/*.rpm"),
 	}
+	hasBasePackages := !skipBase && len(cfg.BasePackages) > 0
 
-	if !skipBase && len(cfg.BasePackages) > 0 {
+	if hasBasePackages {
 		opts := append(opts, dalec.ProgressGroup("Create base virtual package"))
 
 		var basePkgStates []llb.State
@@ -61,7 +62,26 @@ func (cfg *Config) BuildContainer(ctx context.Context, client gwclient.Client, s
 		}
 
 		basePkgs = dalec.MergeAtPath(basePkgs, basePkgStates, "/", opts...)
-		pkgs = append(pkgs, filepath.Join(baseMountPath, "**/*.rpm"))
+		if !cfg.InstallBasePackagesSeparately {
+			pkgs = append(pkgs, filepath.Join(baseMountPath, "**/*.rpm"))
+		}
+	}
+
+	worker := cfg.Worker(sOpt, dalec.Platform(sOpt.TargetPlatform), dalec.WithConstraints(opts...))
+
+	if hasBasePackages && cfg.InstallBasePackagesSeparately {
+		baseInstallOpts := []DnfInstallOpt{
+			DnfAtRoot(workPath),
+			DnfWithSourceOpts(sOpt),
+			DnfInstallWithConstraints(opts),
+			IncludeDocs(spec.GetArtifacts(targetKey).HasDocs()),
+		}
+		rootfs = worker.Run(
+			dalec.WithConstraints(opts...),
+			cfg.Install([]string{filepath.Join(baseMountPath, "**/*.rpm")}, baseInstallOpts...),
+			llb.AddMount(baseMountPath, basePkgs, llb.SourcePath("/RPMS")),
+			frontend.IgnoreCache(client, targets.IgnoreCacheKeyContainer),
+		).AddMount(workPath, rootfs)
 	}
 
 	minimize := !skipBase && spec.GetImageMinimizationProfile(targetKey) == dalec.ImageMinimizationProfileDefault
@@ -69,18 +89,33 @@ func (cfg *Config) BuildContainer(ctx context.Context, client gwclient.Client, s
 		installOpts = append(installOpts, minimizeInstall(opts...))
 	}
 
-	worker := cfg.Worker(sOpt, dalec.Platform(sOpt.TargetPlatform), dalec.WithConstraints(opts...))
-
-	rootfs = worker.Run(
+	runOpts := []llb.RunOption{
 		dalec.WithConstraints(opts...), // Make sure constraints (and platform specifically) are applied before install is set
 		cfg.Install(pkgs, installOpts...),
 		llb.AddMount(rpmMountDir, rpmDir, llb.SourcePath("/RPMS")),
-		llb.AddMount(baseMountPath, basePkgs, llb.SourcePath("/RPMS")),
 		frontend.IgnoreCache(client, targets.IgnoreCacheKeyContainer),
+	}
+	if hasBasePackages {
+		// The minimizer uses both RPM mounts to determine the packages that must
+		// remain, even when the base package was installed in an earlier run.
+		runOpts = append(runOpts, llb.AddMount(baseMountPath, basePkgs, llb.SourcePath("/RPMS")))
+	}
+
+	rootfs = worker.Run(
+		runOpts...,
 	).AddMount(workPath, rootfs)
 
 	if post := spec.GetImagePost(targetKey); post != nil && len(post.Symlinks) > 0 {
 		rootfs = rootfs.With(dalec.InstallPostSymlinks(post, worker, frontend.NativeSymlinkSupport(client), opts...))
+	}
+
+	if minimize && hasBasePackages && cfg.InstallBasePackagesSeparately {
+		squashOpts := append(opts, dalec.ProgressGroup("Squash RPM container"))
+		rootfs = llb.Scratch().File(llb.Copy(rootfs, "/", "/", &llb.CopyInfo{
+			CopyDirContentsOnly: true,
+			CreateDestPath:      true,
+			AllowWildcard:       true,
+		}), squashOpts...)
 	}
 
 	return rootfs

--- a/targets/linux/rpm/distro/container_test.go
+++ b/targets/linux/rpm/distro/container_test.go
@@ -1,0 +1,198 @@
+package distro
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/client/llb/sourceresolver"
+	gwclient "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/solver/pb"
+	"github.com/opencontainers/go-digest"
+	"github.com/project-dalec/dalec"
+	"github.com/project-dalec/dalec/internal/test"
+	"gotest.tools/v3/assert"
+)
+
+func TestBuildContainerBasePackageInstallOrder(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		separate     bool
+		wantInstalls [][]string
+	}{
+		{
+			name:     "combined",
+			separate: false,
+			wantInstalls: [][]string{{
+				"/tmp/rpms/**/*.rpm",
+				"/tmp/rpms-base/**/*.rpm",
+			}},
+		},
+		{
+			name:     "separate",
+			separate: true,
+			wantInstalls: [][]string{
+				{"/tmp/rpms-base/**/*.rpm"},
+				{"/tmp/rpms/**/*.rpm"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var installs [][]string
+			var installConfigs []*dnfInstallConfig
+			cfg := &Config{
+				ContextRef: "worker",
+				BasePackages: []dalec.Spec{{
+					Name:        "dalec-base-test",
+					Version:     "1.0.0",
+					Revision:    "1",
+					License:     "MIT",
+					Description: "Test base package",
+				}},
+				InstallBasePackagesSeparately: tc.separate,
+				InstallFunc: func(cfg *dnfInstallConfig, _ string, pkgs []string) llb.RunOption {
+					installs = append(installs, append([]string(nil), pkgs...))
+					installConfigs = append(installConfigs, cfg)
+					return llb.Args(append([]string{"install"}, pkgs...))
+				},
+			}
+			sOpt := dalec.SourceOpts{
+				GetContext: func(string, ...llb.LocalOption) (*llb.State, error) {
+					st := llb.Scratch()
+					return &st, nil
+				},
+			}
+			spec := &dalec.Spec{
+				Dependencies: &dalec.PackageDependencies{
+					ExtraRepos: []dalec.PackageRepositoryConfig{
+						{
+							Config: map[string]dalec.Source{
+								"test.repo": {
+									Inline: &dalec.SourceInline{
+										File: &dalec.SourceInlineFile{Contents: "[test]"},
+									},
+								},
+							},
+							Envs: []string{"install"},
+						},
+					},
+				},
+			}
+
+			cfg.BuildContainer(
+				context.Background(),
+				&containerTestClient{},
+				sOpt,
+				spec,
+				"test",
+				llb.Scratch(),
+			)
+
+			assert.DeepEqual(t, installs, tc.wantInstalls)
+			if tc.separate {
+				assert.Equal(t, len(installConfigs[0].mounts), 0)
+				assert.Equal(t, len(installConfigs[0].keys), 0)
+				assert.Equal(t, len(installConfigs[1].mounts), 1)
+			}
+		})
+	}
+}
+
+func TestBuildContainerSquashesSeparateMinimizedInstall(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		separate   bool
+		wantSquash bool
+	}{
+		{name: "combined", separate: false, wantSquash: false},
+		{name: "separate", separate: true, wantSquash: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &Config{
+				ContextRef: "worker",
+				BasePackages: []dalec.Spec{{
+					Name:        "dalec-base-test",
+					Version:     "1.0.0",
+					Revision:    "1",
+					License:     "MIT",
+					Description: "Test base package",
+				}},
+				InstallBasePackagesSeparately: tc.separate,
+				InstallFunc: func(_ *dnfInstallConfig, _ string, pkgs []string) llb.RunOption {
+					return llb.Args(append([]string{"install"}, pkgs...))
+				},
+			}
+			sOpt := dalec.SourceOpts{
+				GetContext: func(string, ...llb.LocalOption) (*llb.State, error) {
+					st := llb.Scratch()
+					return &st, nil
+				},
+			}
+			spec := &dalec.Spec{
+				Image: &dalec.ImageConfig{
+					MinimizationProfile: dalec.ImageMinimizationProfileDefault,
+				},
+			}
+
+			state := cfg.BuildContainer(
+				context.Background(),
+				&containerTestClient{},
+				sOpt,
+				spec,
+				"test",
+				llb.Scratch(),
+			)
+
+			var foundSquash bool
+			for _, op := range test.LLBOpsFromState(context.Background(), t, state) {
+				if pg := op.OpMetadata.ProgressGroup; pg != nil && pg.Name == "Squash RPM container" {
+					foundSquash = true
+				}
+			}
+			assert.Equal(t, foundSquash, tc.wantSquash)
+		})
+	}
+}
+
+type containerTestClient struct{}
+
+func (c *containerTestClient) BuildOpts() gwclient.BuildOpts {
+	return gwclient.BuildOpts{}
+}
+
+func (c *containerTestClient) Solve(context.Context, gwclient.SolveRequest) (*gwclient.Result, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *containerTestClient) Inputs(context.Context) (map[string]llb.State, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *containerTestClient) NewContainer(context.Context, gwclient.NewContainerRequest) (gwclient.Container, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *containerTestClient) ResolveImageConfig(context.Context, string, sourceresolver.Opt) (string, digest.Digest, []byte, error) {
+	return "", "", nil, errors.New("not implemented")
+}
+
+func (c *containerTestClient) ResolveSourceMetadata(context.Context, *pb.SourceOp, sourceresolver.Opt) (*sourceresolver.MetaResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *containerTestClient) Warn(context.Context, digest.Digest, string, gwclient.WarnOpts) error {
+	return errors.New("not implemented")
+}

--- a/targets/linux/rpm/distro/distro.go
+++ b/targets/linux/rpm/distro/distro.go
@@ -26,6 +26,9 @@ type Config struct {
 	// Dependencies to install in base image
 	BasePackages       []dalec.Spec
 	RepoPlatformConfig *dalec.RepoPlatformConfig
+	// InstallBasePackagesSeparately bootstraps the base userland before
+	// installing the application RPM and its runtime dependency graph.
+	InstallBasePackagesSeparately bool
 
 	DefaultOutputImage string
 

--- a/targets/linux/rpm/suse/sles15.go
+++ b/targets/linux/rpm/suse/sles15.go
@@ -32,14 +32,15 @@ var ConfigSLES15 = &distro.Config{
 	CacheName: zypperCacheSLES15,
 	CacheDir:  []string{"/var/cache/zypp"},
 
-	ReleaseVer:                  "15",
-	BuilderPackages:             builderPackages,
-	BasePackages:                basePackages(SLES15TargetKey),
-	RepoPlatformConfig:          &defaultPlatformConfig,
-	InstallFunc:                 distro.ZypperInstall,
-	CrossArchInstallUnsupported: true,
-	FullName:                    sles15FullName,
-	RPMMacros:                   sles15RPMMacros,
+	ReleaseVer:                    "15",
+	BuilderPackages:               builderPackages,
+	BasePackages:                  basePackages(SLES15TargetKey),
+	InstallBasePackagesSeparately: true,
+	RepoPlatformConfig:            &defaultPlatformConfig,
+	InstallFunc:                   distro.ZypperInstall,
+	CrossArchInstallUnsupported:   true,
+	FullName:                      sles15FullName,
+	RPMMacros:                     sles15RPMMacros,
 }
 
 // sles15RPMMacros are the rpm macro overrides needed to make SUSE's rpm behave

--- a/test/target_suse_test.go
+++ b/test/target_suse_test.go
@@ -9,8 +9,11 @@ import (
 	"testing"
 
 	"github.com/moby/buildkit/client/llb"
+	gwclient "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/project-dalec/dalec"
+	"github.com/project-dalec/dalec/frontend"
 	"github.com/project-dalec/dalec/targets/linux/rpm/distro"
 	"github.com/project-dalec/dalec/targets/linux/rpm/suse"
 )
@@ -64,10 +67,119 @@ func TestSLES15(t *testing.T) {
 	}
 	testLinuxDistro(ctx, t, cfg)
 	testSuseExtra(ctx, t, cfg, suse.ConfigSLES15.ImageRef)
+	testSLESBasePackageBootstrap(ctx, t, cfg)
 }
 
 func testSuseExtra(ctx context.Context, t *testing.T, cfg testLinuxConfig, distroImageRef string) {
 	testSignedRPMCustomBaseImage(ctx, t, cfg.Target, distroImageRef, true, cfg.Worker)
+}
+
+func testSLESBasePackageBootstrap(ctx context.Context, t *testing.T, cfg testLinuxConfig) {
+	t.Run("base_packages_are_installed_before_application_dependencies", func(t *testing.T) {
+		t.Parallel()
+		ctx := startTestSpan(ctx, t)
+
+		spec := testLinuxSpec(t, dalec.Spec{
+			Dependencies: &dalec.PackageDependencies{
+				Runtime: dalec.PackageDependencyList{
+					"bash":        {},
+					"coreutils":   {},
+					"grep":        {},
+					"libopenssl3": {},
+					"moby-runc": {
+						Version: []string{">= 1.1.0"},
+					},
+				},
+				Recommends: dalec.PackageDependencyList{
+					"git":  {},
+					"pigz": {},
+					"xz":   {},
+				},
+				ExtraRepos: []dalec.PackageRepositoryConfig{
+					{
+						// This intentionally mirrors the external repository and
+						// dependency graph that exposed the combined-transaction
+						// failure. Key rotation or repository changes may require
+						// updating this fixture independently of Dalec.
+						Keys: map[string]dalec.Source{
+							"msft.asc": {
+								HTTP: &dalec.SourceHTTP{
+									URL:         "https://packages.microsoft.com/keys/microsoft.asc",
+									Digest:      digest.Digest("sha256:2fa9c05d591a1582a9aba276272478c262e95ad00acf60eaee1644d93941e3c6"),
+									Permissions: 0o644,
+								},
+							},
+						},
+						Config: map[string]dalec.Source{
+							"microsoft-prod.repo": {
+								Inline: &dalec.SourceInline{
+									File: &dalec.SourceInlineFile{
+										Contents: `[packages-microsoft-com-prod]
+name=Microsoft Production
+baseurl=https://packages.microsoft.com/sles/15/prod/
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=file:///usr/share/pki/rpm-gpg/msft.asc
+sslverify=1
+`,
+									},
+								},
+							},
+						},
+						Envs: []string{"install"},
+					},
+				},
+			},
+			Sources: map[string]dalec.Source{
+				"service.service": {
+					Inline: &dalec.SourceInline{
+						File: &dalec.SourceInlineFile{
+							Contents: `[Unit]
+Description=Dalec SLES bootstrap regression test
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/true
+
+[Install]
+WantedBy=multi-user.target
+`,
+						},
+					},
+				},
+			},
+			Artifacts: dalec.Artifacts{
+				Systemd: &dalec.SystemdConfiguration{
+					Units: map[string]dalec.SystemdUnitConfig{
+						"service.service": {Enable: true},
+					},
+				},
+			},
+			Tests: []*dalec.TestSpec{
+				{
+					Name: "base and application packages installed",
+					Files: map[string]dalec.FileCheckOutput{
+						"/etc/os-release": {
+							Permissions: 0o644,
+						},
+						filepath.Join(cfg.SystemdDir.Targets, "multi-user.target.wants/service.service"): {
+							LinkTarget: "/usr/lib/systemd/system/service.service",
+						},
+					},
+				},
+			},
+		})
+
+		testEnv.RunTest(ctx, t, func(ctx context.Context, client gwclient.Client) {
+			req := newSolveRequest(
+				withSpec(ctx, t, &spec),
+				withBuildTarget(cfg.Target.Container),
+				withIgnoreCache(frontend.IgnoreCacheTestsKey),
+			)
+			solveT(ctx, t, client, req)
+		})
+	})
 }
 
 // suseListSignFiles lists the rpm artifacts expected to be signed for SUSE.


### PR DESCRIPTION
Install the SLES base userland before the application RPM and its runtime dependency graph. This prevents package scriptlets from invoking a partially installed shell while preserving dependency resolution behavior for other RPM targets.

**What this PR does / why we need it**:

- Adds an opt-in separate base-package installation transaction and enables it for SLES 15.
- Keeps the existing combined transaction for Azure Linux, AlmaLinux, and Rocky Linux so strong application dependencies can override weak base-package recommendations.
- Squashes minimized output filesystems when separate base-package installation creates an additional layer.
- Adds focused coverage for combined and separate installation order and conditional layer squashing.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:

None.

**Special notes for your reviewer**:

The generic split-transaction approach caused the Azure Linux `ca-certs_override` integration test to fail because a weak `prebuilt-ca-certificates` recommendation was committed before the application dependency could override it. The split is therefore intentionally scoped to SLES.