### PR TITLE
deb: declare Standards-Version 4.7.4 in generated control file

### DIFF
--- a/packaging/linux/deb/debroot.go
+++ b/packaging/linux/deb/debroot.go
@@ -21,7 +21,10 @@ import (
 )
 
 const (
-	DebHelperCompat           = "11"
+	DebHelperCompat = "11"
+	// StandardsVersion is the version of the Debian Policy Manual that
+	// generated packages declare compliance with in debian/control.
+	StandardsVersion          = "4.7.4"
 	customSystemdPostinstFile = "custom_systemd_postinst.sh.partial"
 	BinariesPath              = "/usr/bin"
 	ConfigFilesPath           = "/etc"

--- a/packaging/linux/deb/template_control.go
+++ b/packaging/linux/deb/template_control.go
@@ -49,6 +49,12 @@ func (w *controlWrapper) Maintainer() string {
 	return p + " <" + placeholderMaintainerEmail + ">"
 }
 
+// StandardsVersion returns the Debian Policy Manual version declared in the
+// generated debian/control file's Standards-Version field.
+func (w *controlWrapper) StandardsVersion() string {
+	return StandardsVersion
+}
+
 // NOTE: This is very basic and does not handle things like grouped constraints
 // Given this is just trying to shim things to allow either the rpm format or the deb format
 // in its basic form, this is sufficient for now.

--- a/packaging/linux/deb/template_control_test.go
+++ b/packaging/linux/deb/template_control_test.go
@@ -1,6 +1,7 @@
 package deb
 
 import (
+	"bytes"
 	"reflect"
 	"strings"
 	"testing"
@@ -25,6 +26,22 @@ func TestControlWrapperMaintainer(t *testing.T) {
 		w := &controlWrapper{Spec: &dalec.Spec{}}
 		assert.Equal(t, w.Maintainer(), "")
 	})
+}
+
+func TestWriteControlStandardsVersion(t *testing.T) {
+	spec := &dalec.Spec{
+		Name:     "foo",
+		Packager: "Dalec <maint@example.com>",
+	}
+
+	var buf bytes.Buffer
+	err := WriteControl(spec, "any-target", &buf)
+	assert.NilError(t, err)
+
+	out := buf.String()
+	want := "Standards-Version:" + StandardsVersion
+	assert.Equal(t, strings.Count(out, "Standards-Version:"), 1, "expected exactly one Standards-Version field, got:\n%s", out)
+	assert.Assert(t, cmp.Contains(out, want))
 }
 
 func TestAppendConstraints(t *testing.T) {

--- a/packaging/linux/deb/templates/debian_control.tmpl
+++ b/packaging/linux/deb/templates/debian_control.tmpl
@@ -1,5 +1,6 @@
 Source: {{- .Name -}}{{- "\n" -}}
 {{- if .Maintainer }}Maintainer: {{- .Maintainer -}}{{- "\n" -}}{{end -}}
+Standards-Version: {{- .StandardsVersion -}}{{- "\n" -}}
 {{- if .Website}}Homepage: {{- .Website -}}{{- "\n" -}}{{end -}}
 {{- .BuildDeps }}
 


### PR DESCRIPTION
PMC source ingestion requires a `Standards-Version` field in `debian/control`. This adds it as a package const in `packaging/linux/deb` and wires it through the existing `controlWrapper` template data conventions, alongside `DebHelperCompat`.

Scope is limited to the Standards-Version field; no copyright handling or other compliance changes are included.

Adds a focused test (`TestWriteControlStandardsVersion`) verifying the generated control content includes exactly one `Standards-Version` field with the expected value.