### PR TITLE
Backport Debian Standards-Version metadata to 0.19

### DIFF
--- a/packaging/linux/deb/debroot.go
+++ b/packaging/linux/deb/debroot.go
@@ -22,6 +22,7 @@ import (
 
 const (
 	DebHelperCompat           = "11"
+	StandardsVersion          = "4.7.4"
 	customSystemdPostinstFile = "custom_systemd_postinst.sh.partial"
 	BinariesPath              = "/usr/bin"
 	ConfigFilesPath           = "/etc"

--- a/packaging/linux/deb/template_control.go
+++ b/packaging/linux/deb/template_control.go
@@ -14,12 +14,17 @@ import (
 )
 
 func WriteControl(spec *dalec.Spec, target string, w io.Writer) error {
-	return controlTmpl.Execute(w, &controlWrapper{spec, target})
+	return controlTmpl.Execute(w, &controlWrapper{
+		Spec:             spec,
+		Target:           target,
+		StandardsVersion: StandardsVersion,
+	})
 }
 
 type controlWrapper struct {
 	*dalec.Spec
-	Target string
+	Target           string
+	StandardsVersion string
 }
 
 func (w *controlWrapper) Architecture() string {

--- a/packaging/linux/deb/template_control_test.go
+++ b/packaging/linux/deb/template_control_test.go
@@ -9,6 +9,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestWriteControl(t *testing.T) {
+	t.Run("Generated control declares the Debian standards version in the source stanza", func(t *testing.T) {
+		spec := &dalec.Spec{Name: "test-pkg"}
+		var output strings.Builder
+
+		err := WriteControl(spec, "target", &output)
+
+		const expected = "Standards-Version: 4.7.4" + string(byte(10))
+		control := output.String()
+		standardsVersionIndex := strings.Index(control, expected)
+		packageIndex := strings.Index(control, string(byte(10))+"Package:")
+		require.NoError(t, err)
+		require.Contains(t, control, expected)
+		require.Equal(t, 1, strings.Count(control, "Standards-Version:"))
+		require.GreaterOrEqual(t, packageIndex, 0)
+		require.Less(t, standardsVersionIndex, packageIndex)
+	})
+}
+
 func TestAppendConstraints(t *testing.T) {
 	tests := []struct {
 		name string
@@ -104,7 +123,7 @@ func TestControlWrapper_ReplacesConflictsProvides(t *testing.T) {
 		}
 
 		// Test target1
-		wrapper1 := &controlWrapper{spec, "target1"}
+		wrapper1 := &controlWrapper{Spec: spec, Target: "target1"}
 
 		// Test Replaces
 		replaces := wrapper1.Replaces().String()
@@ -119,7 +138,7 @@ func TestControlWrapper_ReplacesConflictsProvides(t *testing.T) {
 		require.Contains(t, provides, "Provides: pkg-c")
 
 		// Test target2
-		wrapper2 := &controlWrapper{spec, "target2"}
+		wrapper2 := &controlWrapper{Spec: spec, Target: "target2"}
 
 		// Test Replaces
 		replaces = wrapper2.Replaces().String()
@@ -150,7 +169,7 @@ func TestControlWrapper_ReplacesConflictsProvides(t *testing.T) {
 		}
 
 		// Test with any target name
-		wrapper := &controlWrapper{spec, "any-target"}
+		wrapper := &controlWrapper{Spec: spec, Target: "any-target"}
 
 		// Test Replaces
 		replaces := wrapper.Replaces().String()
@@ -172,7 +191,7 @@ func TestControlWrapper_ReplacesConflictsProvides(t *testing.T) {
 			// No Replaces, Conflicts, or Provides defined
 		}
 
-		wrapper := &controlWrapper{spec, "target1"}
+		wrapper := &controlWrapper{Spec: spec, Target: "target1"}
 
 		// Test empty values
 		require.Equal(t, "", wrapper.Replaces().String())
@@ -191,7 +210,7 @@ func TestControlWrapper_ReplacesConflictsProvides(t *testing.T) {
 			},
 		}
 
-		wrapper := &controlWrapper{spec, "any-target"}
+		wrapper := &controlWrapper{Spec: spec, Target: "any-target"}
 		replaces := wrapper.Replaces().String()
 
 		// Test multiline formatting
@@ -249,7 +268,7 @@ func TestControlWrapper_ReplacesConflictsProvides(t *testing.T) {
 		}
 
 		// Test target1 (should see target-specific values taking precedence)
-		wrapper1 := &controlWrapper{spec, "target1"}
+		wrapper1 := &controlWrapper{Spec: spec, Target: "target1"}
 
 		// Test Replaces - should contain target-specific values and not root values for common-pkg
 		replaces := wrapper1.Replaces().String()
@@ -277,7 +296,7 @@ func TestControlWrapper_ReplacesConflictsProvides(t *testing.T) {
 
 		// Test with non-existent target to get root values
 		// Current implementation only falls back to root if target doesn't exist
-		wrapperNonExistent := &controlWrapper{spec, "non-existent-target"}
+		wrapperNonExistent := &controlWrapper{Spec: spec, Target: "non-existent-target"}
 
 		// Test Replaces - should contain root values
 		replaces = wrapperNonExistent.Replaces().String()
@@ -295,7 +314,7 @@ func TestControlWrapper_ReplacesConflictsProvides(t *testing.T) {
 		require.Contains(t, provides, "root-pkg-p (= 5.0.0)")
 
 		// Test target2 - should return empty values because the maps are explicitly empty
-		wrapper2 := &controlWrapper{spec, "target2"}
+		wrapper2 := &controlWrapper{Spec: spec, Target: "target2"}
 		require.Equal(t, "", wrapper2.Replaces().String())
 		require.Equal(t, "", wrapper2.Conflicts().String())
 		require.Equal(t, "", wrapper2.Provides().String())

--- a/packaging/linux/deb/template_control_test.go
+++ b/packaging/linux/deb/template_control_test.go
@@ -16,10 +16,10 @@ func TestWriteControl(t *testing.T) {
 
 		err := WriteControl(spec, "target", &output)
 
-		const expected = "Standards-Version: 4.7.4" + string(byte(10))
+		const expected = "Standards-Version: 4.7.4\n"
 		control := output.String()
 		standardsVersionIndex := strings.Index(control, expected)
-		packageIndex := strings.Index(control, string(byte(10))+"Package:")
+		packageIndex := strings.Index(control, "\nPackage:")
 		require.NoError(t, err)
 		require.Contains(t, control, expected)
 		require.Equal(t, 1, strings.Count(control, "Standards-Version:"))

--- a/packaging/linux/deb/templates/debian_control.tmpl
+++ b/packaging/linux/deb/templates/debian_control.tmpl
@@ -1,6 +1,7 @@
 Source: {{- .Name -}}{{- "\n" -}}
 {{- if .Packager }}Maintainer: {{- .Packager -}}{{- "\n" -}}{{end -}}
 {{- if .Website}}Homepage: {{- .Website -}}{{- "\n" -}}{{end -}}
+Standards-Version: {{.StandardsVersion -}}{{- "\n" -}}
 {{- .BuildDeps }}
 
 Package: {{- .Name -}}{{- "\n" -}}


### PR DESCRIPTION
Backport of #1222 to release/0.19.\n\nAdds Debian Standards-Version 4.7.4 metadata and focused coverage.\n\nValidation: go test -timeout=15m ./packaging/linux/deb; go run ./cmd/lint ./...; go generate ./... && git diff --exit-code; git diff --check.