### PR TITLE
Backport Debian Standards-Version metadata to release/0.20

### DIFF
--- a/packaging/linux/deb/debroot.go
+++ b/packaging/linux/deb/debroot.go
@@ -22,6 +22,7 @@ import (
 
 const (
 	DebHelperCompat           = "11"
+	StandardsVersion          = "4.7.4"
 	customSystemdPostinstFile = "custom_systemd_postinst.sh.partial"
 	BinariesPath              = "/usr/bin"
 	ConfigFilesPath           = "/etc"

--- a/packaging/linux/deb/template_control.go
+++ b/packaging/linux/deb/template_control.go
@@ -14,12 +14,17 @@ import (
 )
 
 func WriteControl(spec *dalec.Spec, target string, w io.Writer) error {
-	return controlTmpl.Execute(w, &controlWrapper{spec, target})
+	return controlTmpl.Execute(w, &controlWrapper{
+		Spec:             spec,
+		Target:           target,
+		StandardsVersion: StandardsVersion,
+	})
 }
 
 type controlWrapper struct {
 	*dalec.Spec
-	Target string
+	Target           string
+	StandardsVersion string
 }
 
 func (w *controlWrapper) Architecture() string {

--- a/packaging/linux/deb/template_control_test.go
+++ b/packaging/linux/deb/template_control_test.go
@@ -10,6 +10,25 @@ import (
 	"gotest.tools/v3/assert/cmp"
 )
 
+func TestWriteControl(t *testing.T) {
+	t.Run("Generated control declares the Debian standards version in the source stanza", func(t *testing.T) {
+		spec := &dalec.Spec{Name: "test-pkg"}
+		var output strings.Builder
+
+		err := WriteControl(spec, "target", &output)
+
+		const expected = "Standards-Version: 4.7.4\n"
+		control := output.String()
+		standardsVersionIndex := strings.Index(control, expected)
+		packageIndex := strings.Index(control, "\nPackage:")
+		assert.NilError(t, err)
+		assert.Assert(t, cmp.Contains(control, expected))
+		assert.Equal(t, strings.Count(control, "Standards-Version:"), 1)
+		assert.Assert(t, packageIndex >= 0)
+		assert.Assert(t, standardsVersionIndex < packageIndex)
+	})
+}
+
 func TestAppendConstraints(t *testing.T) {
 	tests := []struct {
 		name string
@@ -105,7 +124,7 @@ func TestControlWrapper_ReplacesConflictsProvides(t *testing.T) {
 		}
 
 		// Test target1
-		wrapper1 := &controlWrapper{spec, "target1"}
+		wrapper1 := &controlWrapper{Spec: spec, Target: "target1"}
 
 		// Test Replaces
 		replaces := wrapper1.Replaces().String()
@@ -120,7 +139,7 @@ func TestControlWrapper_ReplacesConflictsProvides(t *testing.T) {
 		assert.Assert(t, cmp.Contains(provides, "Provides: pkg-c"))
 
 		// Test target2
-		wrapper2 := &controlWrapper{spec, "target2"}
+		wrapper2 := &controlWrapper{Spec: spec, Target: "target2"}
 
 		// Test Replaces
 		replaces = wrapper2.Replaces().String()
@@ -151,7 +170,7 @@ func TestControlWrapper_ReplacesConflictsProvides(t *testing.T) {
 		}
 
 		// Test with any target name
-		wrapper := &controlWrapper{spec, "any-target"}
+		wrapper := &controlWrapper{Spec: spec, Target: "any-target"}
 
 		// Test Replaces
 		replaces := wrapper.Replaces().String()
@@ -173,7 +192,7 @@ func TestControlWrapper_ReplacesConflictsProvides(t *testing.T) {
 			// No Replaces, Conflicts, or Provides defined
 		}
 
-		wrapper := &controlWrapper{spec, "target1"}
+		wrapper := &controlWrapper{Spec: spec, Target: "target1"}
 
 		// Test empty values
 		assert.DeepEqual(t, wrapper.Replaces().String(), "")
@@ -192,7 +211,7 @@ func TestControlWrapper_ReplacesConflictsProvides(t *testing.T) {
 			},
 		}
 
-		wrapper := &controlWrapper{spec, "any-target"}
+		wrapper := &controlWrapper{Spec: spec, Target: "any-target"}
 		replaces := wrapper.Replaces().String()
 
 		// Test multiline formatting
@@ -250,7 +269,7 @@ func TestControlWrapper_ReplacesConflictsProvides(t *testing.T) {
 		}
 
 		// Test target1 (should see target-specific values taking precedence)
-		wrapper1 := &controlWrapper{spec, "target1"}
+		wrapper1 := &controlWrapper{Spec: spec, Target: "target1"}
 
 		// Test Replaces - should contain target-specific values and not root values for common-pkg
 		replaces := wrapper1.Replaces().String()
@@ -278,7 +297,7 @@ func TestControlWrapper_ReplacesConflictsProvides(t *testing.T) {
 
 		// Test with non-existent target to get root values
 		// Current implementation only falls back to root if target doesn't exist
-		wrapperNonExistent := &controlWrapper{spec, "non-existent-target"}
+		wrapperNonExistent := &controlWrapper{Spec: spec, Target: "non-existent-target"}
 
 		// Test Replaces - should contain root values
 		replaces = wrapperNonExistent.Replaces().String()
@@ -296,7 +315,7 @@ func TestControlWrapper_ReplacesConflictsProvides(t *testing.T) {
 		assert.Assert(t, cmp.Contains(provides, "root-pkg-p (= 5.0.0)"))
 
 		// Test target2 - should return empty values because the maps are explicitly empty
-		wrapper2 := &controlWrapper{spec, "target2"}
+		wrapper2 := &controlWrapper{Spec: spec, Target: "target2"}
 		assert.DeepEqual(t, wrapper2.Replaces().String(), "")
 		assert.DeepEqual(t, wrapper2.Conflicts().String(), "")
 		assert.DeepEqual(t, wrapper2.Provides().String(), "")

--- a/packaging/linux/deb/templates/debian_control.tmpl
+++ b/packaging/linux/deb/templates/debian_control.tmpl
@@ -1,6 +1,7 @@
 Source: {{- .Name -}}{{- "\n" -}}
 {{- if .Packager }}Maintainer: {{- .Packager -}}{{- "\n" -}}{{end -}}
 {{- if .Website}}Homepage: {{- .Website -}}{{- "\n" -}}{{end -}}
+Standards-Version: {{.StandardsVersion -}}{{- "\n" -}}
 {{- .BuildDeps }}
 
 Package: {{- .Name -}}{{- "\n" -}}


### PR DESCRIPTION
Backport of #1222 to `release/0.20`.

- Declare Debian Standards-Version 4.7.4.
- Emit it in the source control stanza.
- Add focused control-generation coverage.

Cherry-picks 355a6754 and 518bdfbb.