### PR TITLE
Do not apply source filter for base images

### DIFF
--- a/image.go
+++ b/image.go
@@ -267,6 +267,14 @@ func (bi *BaseImage) ToState(sOpt SourceOpts, opts ...llb.ConstraintsOpt) llb.St
 	if bi == nil {
 		return llb.Scratch()
 	}
+
+	// The SourceFilter is intended for actual build sources, not base images.
+	// Do not apply source filter to the base image.
+	//
+	// NOTE: Applying a source filter on Windows is catastrophic because windows layers are special
+	// When applying a source filter, data is copied to an llb.Scratch(), which makes buildkit lose track
+	// of the special behavior for the windows layers.
+	sOpt.SourceFilter = nil
 	return bi.Rootfs.ToState("", sOpt, opts...)
 }
 

--- a/image_test.go
+++ b/image_test.go
@@ -1,0 +1,27 @@
+package dalec
+
+import (
+	"context"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestBaseImage_does_not_apply_source_filters(t *testing.T) {
+	bi := BaseImage{
+		Rootfs: Source{
+			DockerImage: &SourceDockerImage{Ref: "example.invalid/base:latest"},
+		},
+	}
+
+	sOpt := SourceOpts{
+		SourceFilter: func() (SourceFilterConfig, error) {
+			t.Fatal("source filter called for base image")
+			return SourceFilterConfig{}, nil
+		},
+	}
+
+	_, err := bi.ToState(sOpt).Marshal(context.Background())
+	assert.NilError(t, err)
+	assert.Assert(t, sOpt.SourceFilter != nil)
+}


### PR DESCRIPTION
Source filters are for filtering stuff in the actual build sources. Base images are build outputs and not intended for filtering.

This fixes a critical issue for Windows builds.
The way source filters work caused the base Windows layers to be squashed and loose important data and buildkit produces a malformed image (for windows).

Example of a correct windows base layer content:

  Files/
  Files/Windows/
  Files/Windows/System32/
  Files/Windows/System32/config/
  Files/Windows/System32/config/SOFTWARE
  Files/Windows/System32/config/SYSTEM
  Files/Windows/System32/config/SAM
  Files/Windows/System32/config/SECURITY
  Files/Windows/System32/config/DEFAULT
  Files/cc0-legalcode.txt
  Files/License.txt

Example of malformed layer before this change content:

  License.txt
  Windows/
  Windows/System32/
  Windows/System32/config/
  Windows/System32/config/DEFAULT
  Windows/System32/config/SAM
  Windows/System32/config/SECURITY
  Windows/System32/config/SOFTWARE
  Windows/System32/config/SYSTEM
  cc0-legalcode.txt

When squashing the windows layer there is no data that tells buildkit that the layer is a windows layer and it produces incorrect output.
