### PR TITLE
[release/0.22] Do not apply source filters to base images

### DIFF
--- a/image.go
+++ b/image.go
@@ -257,6 +257,14 @@ func (bi *BaseImage) ToState(sOpt SourceOpts, opts ...llb.ConstraintsOpt) llb.St
 	if bi == nil {
 		return llb.Scratch()
 	}
+
+	// The SourceFilter is intended for actual build sources, not base images.
+	// Do not apply source filter to the base image.
+	//
+	// NOTE: Applying a source filter on Windows is catastrophic because windows layers are special
+	// When applying a source filter, data is copied to an llb.Scratch(), which makes buildkit lose track
+	// of the special behavior for the windows layers.
+	sOpt.SourceFilter = nil
 	return bi.Rootfs.ToState("", sOpt, opts...)
 }
 

--- a/image_test.go
+++ b/image_test.go
@@ -1,0 +1,27 @@
+package dalec
+
+import (
+	"context"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestBaseImage_does_not_apply_source_filters(t *testing.T) {
+	bi := BaseImage{
+		Rootfs: Source{
+			DockerImage: &SourceDockerImage{Ref: "example.invalid/base:latest"},
+		},
+	}
+
+	sOpt := SourceOpts{
+		SourceFilter: func() (SourceFilterConfig, error) {
+			t.Fatal("source filter called for base image")
+			return SourceFilterConfig{}, nil
+		},
+	}
+
+	_, err := bi.ToState(sOpt).Marshal(context.Background())
+	assert.NilError(t, err)
+	assert.Assert(t, sOpt.SourceFilter != nil)
+}


### PR DESCRIPTION
Backport of #1228.

v0.22.0 can rematerialize container base images when source filtering is enabled, causing BuildKit to lose Windows layer semantics and produce malformed Windows layers. Clear `SourceFilter` only on the value-copy used by `BaseImage.ToState`; package sources continue to retain source filtering.

Tests:
- `go test . -run ^'TestBaseImage_does_not_apply_source_filters$' -count=1`\n- `go run ./cmd/lint ./...`\n- `go generate ./... && git diff --exit-code`