### PR TITLE
[release/0.21] Do not apply source filters to base images

### DIFF
--- a/image.go
+++ b/image.go
@@ -257,6 +257,14 @@ func (bi *BaseImage) ToState(sOpt SourceOpts, opts ...llb.ConstraintsOpt) llb.St
 	if bi == nil {
 		return llb.Scratch()
 	}
+
+	// The SourceFilter is intended for actual build sources, not base images.
+	// Do not apply source filter to the base image.
+	//
+	// NOTE: Applying a source filter on Windows is catastrophic because windows layers are special
+	// When applying a source filter, data is copied to an llb.Scratch(), which makes buildkit lose track
+	// of the special behavior for the windows layers.
+	sOpt.SourceFilter = nil
 	return bi.Rootfs.ToState("", sOpt, opts...)
 }
 

--- a/image_test.go
+++ b/image_test.go
@@ -1,0 +1,27 @@
+package dalec
+
+import (
+	"context"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestBaseImage_does_not_apply_source_filters(t *testing.T) {
+	bi := BaseImage{
+		Rootfs: Source{
+			DockerImage: &SourceDockerImage{Ref: "example.invalid/base:latest"},
+		},
+	}
+
+	sOpt := SourceOpts{
+		SourceFilter: func() (SourceFilterConfig, error) {
+			t.Fatal("source filter called for base image")
+			return SourceFilterConfig{}, nil
+		},
+	}
+
+	_, err := bi.ToState(sOpt).Marshal(context.Background())
+	assert.NilError(t, err)
+	assert.Assert(t, sOpt.SourceFilter != nil)
+}


### PR DESCRIPTION
Backports #1228 / commit 3190d3dc139dd5d983c7b33ef3ff9d84bf241e51.

Affected v0.21 releases can rematerialize container base images under source filtering, corrupting Windows layers. The fix clears the value-copy of SourceOpts.SourceFilter only while resolving BaseImage.Rootfs, preserving package-source filtering.

Validation:
- go test . -run '^TestBaseImage_does_not_apply_source_filters$' -count=1
- go test --test.short --timeout=10m ./...
- go run ./cmd/lint ./...
- go generate && git diff --exit-code