### PR TITLE
[release/0.18] Do not apply source filters to base images

### DIFF
--- a/image.go
+++ b/image.go
@@ -257,6 +257,14 @@ func (bi *BaseImage) ToState(sOpt SourceOpts, opts ...llb.ConstraintsOpt) llb.St
 	if bi == nil {
 		return llb.Scratch()
 	}
+
+	// The SourceFilter is intended for actual build sources, not base images.
+	// Do not apply source filter to the base image.
+	//
+	// NOTE: Applying a source filter on Windows is catastrophic because windows layers are special
+	// When applying a source filter, data is copied to an llb.Scratch(), which makes buildkit lose track
+	// of the special behavior for the windows layers.
+	sOpt.SourceFilter = nil
 	return bi.Rootfs.ToState("", sOpt, opts...)
 }
 

--- a/image_test.go
+++ b/image_test.go
@@ -1,0 +1,27 @@
+package dalec
+
+import (
+	"context"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestBaseImage_does_not_apply_source_filters(t *testing.T) {
+	bi := BaseImage{
+		Rootfs: Source{
+			DockerImage: &SourceDockerImage{Ref: "example.invalid/base:latest"},
+		},
+	}
+
+	sOpt := SourceOpts{
+		SourceFilter: func() (SourceFilterConfig, error) {
+			t.Fatal("source filter called for base image")
+			return SourceFilterConfig{}, nil
+		},
+	}
+
+	_, err := bi.ToState(sOpt).Marshal(context.Background())
+	assert.NilError(t, err)
+	assert.Assert(t, sOpt.SourceFilter != nil)
+}


### PR DESCRIPTION
Backports #1228 (`3190d3dc139dd5d983c7b33ef3ff9d84bf241e51`) to `release/0.18`.

Source filtering was backported in v0.18.3. Applying it to container base images rematerializes them through scratch, which loses Windows layer semantics and can produce corrupt images. This keeps source filtering for package sources while clearing it only for base image resolution.

Tests:
- `go test --test.short --timeout=10m -run '^TestBaseImage_does_not_apply_source_filters$' .`\n- `go test --test.short --timeout=10m -run '^(TestSourceFilterAtPath|TestSourceFilter|TestSourceFilterEmptyNoop)$' .`\n- `go test --test.short --timeout=10m ./...`\n- `go run ./cmd/lint ./...`\n- `go generate ./... && git diff --exit-code`